### PR TITLE
Add script to generate api documentation for mkdocs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,41 @@
+name: Build Documentation with mkdocs
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build_docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.12
+
+      - name: Install mkdocs dependencies
+        run: |
+          pip install mkdocs mkdocs-material
+
+      - name: Set up Go 1.24
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24
+
+      - name: Install crdoc
+        run: |
+          go install fybrik.io/crdoc@latest
+
+      - name: Generate API docs
+        run: |
+          bash scripts/build_docs.sh
+
+      - name: Publish docs to Github pages
+        run: |
+          mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.devcontainer
+.vscode
+venv
+cr-*
+docs/apis/*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
 # provider-storage
+
+A Crossplane Configuration Package to provision S3 compatible buckets with fine grained permissions for MinIO.
+
+Documentation: [https://versioneer-tech.github.io/provider-storage/](https://versioneer-tech.github.io/provider-storage/)
+
+## Installation
+
+The `provider-storage` configuration package depends on:
+
+- `crossplane>=v1.20.0`
+- `provider-minio>=v0.4.4`
+- `function-go-templating>=v0.10.0`
+
+These dependencies have to be running before the `provider-storage` can be installed with a Crossplane Configuration:
+
+```yaml
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: provider-storage
+spec:
+  package: ghcr.io/versioneer-tech/provider-storage:0.0.1-dev
+```
+
+After applying the above manifest, the `xstorages.epca.eo` XRD and the `storage` Composition are installed to the cluster and ready to use.
+
+## Usage
+
+A minimal example to create a new bucket with the owner set to `alice`:
+
+```yaml
+apiVersion: epca.eo/v1beta1
+kind: Storage
+metadata:
+  name: test-bucket
+spec:
+  buckets:
+    - name: testeroni
+      owner: alice
+```
+
+This will automatically create a new bucket named `test-bucket` and a new user named `alice` on MinIO. Furthermore, it attaches a Policy to the user `alice` that allows every action.
+

--- a/apis/definition.yaml
+++ b/apis/definition.yaml
@@ -1,0 +1,41 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xstorages.epca.eo
+spec:
+  group: epca.eo
+  names:
+    kind: XStorage
+    plural: xstorages
+  claimNames:
+    kind: Storage
+    plural: storages
+  versions:
+    - name: v1beta1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                buckets:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      owner:
+                        type: string
+                      accessReadWrite:
+                        type: array
+                        items:
+                          type: string
+                      accessReadOnly:
+                        type: array
+                        items:
+                          type: string
+                  default: []

--- a/apis/definition.yaml
+++ b/apis/definition.yaml
@@ -30,12 +30,4 @@ spec:
                         type: string
                       owner:
                         type: string
-                      accessReadWrite:
-                        type: array
-                        items:
-                          type: string
-                      accessReadOnly:
-                        type: array
-                        items:
-                          type: string
                   default: []

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,7 @@
+site_name: provider-storage
+nav:
+  - Reference: apis/definition.md
+plugins:
+  - search
+theme:
+  name: material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,8 @@
 site_name: provider-storage
+site_url: https://versioneer-tech.github.io/provider-storage/
 nav:
-  - Reference: apis/definition.md
+  - API:
+    - Reference: apis/definition.md
 plugins:
   - search
 theme:

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cp apis/definition.yaml cr-definition.yaml
+sed -i 's/CompositeResourceDefinition/CustomResourceDefinition/' cr-definition.yaml
+sed -i 's/apiextensions.crossplane.io\/v1/apiextensions.k8s.io\/v1/g' cr-definition.yaml 
+
+crdoc -r cr-definition.yaml -o docs/apis/definition.md


### PR DESCRIPTION
After looking through different projects that create documentation for CRDs and trying to see if they could be adapated easily to XRDs, I came to the conclusion that the easiest way to achieve our goal is to replace the `apiVersion` and `kind` in the XRD definition file and use an existing tool called [crdoc](https://github.com/fybrik/crdoc).

Currently, there is no Github Action to automatically publish the documentation as this PR is mainly for seeing if we want to continue with this approach.

To serve the documentation locally you have to:
- Install `crdoc` via your preferred method (see [link](https://github.com/fybrik/crdoc))
- Install `mkdocs` and `mkdocs-material` with `pip`
- Run the `build_docs.sh` (located in the `scripts` directory) from the root directory of the project
- Run `mkdocs serve` and navigate to the `Reference` page

![pr-2](https://github.com/user-attachments/assets/e2650ecb-2882-4a5a-8b0e-40c71060de42)