### PR TITLE
Add minimal example for the function-go-templating and EnvironmentConfigs and CompositeConnectionDetails

### DIFF
--- a/claim.yaml
+++ b/claim.yaml
@@ -1,0 +1,8 @@
+apiVersion: epca.eo/v1beta1
+kind: Storage
+metadata:
+  name: test-bucket
+spec:
+  owner: alice
+  writeConnectionSecretToRef:
+    name: connection-secret-alice

--- a/composition.yaml
+++ b/composition.yaml
@@ -20,7 +20,7 @@ spec:
             - type: Reference
               ref:
                 name: test-environment-config
-    - step: setup-minio
+    - step: setup-minio-user
       functionRef:
         name: function-go-templating
       input:
@@ -46,7 +46,17 @@ spec:
               writeConnectionSecretToRef:
                 name: {{ $owner }}
                 namespace: default
+    - step: create-composite-connection-details
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
             ---
+            {{ $owner := .observed.composite.resource.spec.owner }}
             {{ $user := get .observed.resources (printf "%s" $owner) | default dict }}
             apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
             kind: CompositeConnectionDetails

--- a/composition.yaml
+++ b/composition.yaml
@@ -1,0 +1,57 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: storage
+spec:
+  compositeTypeRef:
+    apiVersion: epca.eo/v1beta1
+    kind: XStorage
+  writeConnectionSecretsToNamespace: default
+  mode: Pipeline
+  pipeline:
+    - step: load-environment-config
+      functionRef:
+        name: function-environment-configs
+      input:
+        apiVersion: environmentconfigs.fn.crossplane.io/v1beta1
+        kind: Input
+        spec:
+          environmentConfigs:
+            - type: Reference
+              ref:
+                name: test-environment-config
+    - step: setup-minio
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            {{ $owner := .observed.composite.resource.spec.owner }}
+            ---
+            apiVersion: minio.crossplane.io/v1
+            kind: User
+            metadata:
+              name: {{ $owner }}
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: {{ $owner }}
+                gotemplating.fn.crossplane.io/ready: "True"
+            spec:
+              forProvider:
+                userName: {{ $owner }}
+              providerConfigRef:
+                name: provider-minio
+              writeConnectionSecretToRef:
+                name: {{ $owner }}
+                namespace: default
+            ---
+            {{ $user := get .observed.resources (printf "%s" $owner) | default dict }}
+            apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
+            kind: CompositeConnectionDetails
+            data:
+              AWS_ACCESS_KEY_ID: {{ $user.connectionDetails.AWS_ACCESS_KEY_ID }}
+              AWS_SECRET_ACCESS_KEY: {{ $user.connectionDetails.AWS_SECRET_ACCESS_KEY }}
+              AWS_ENDPOINT_URL: {{ index .context "apiextensions.crossplane.io/environment" "storage.endpoint" | b64enc }}
+              AWS_REGION: {{ index .context "apiextensions.crossplane.io/environment" "storage.region" | b64enc }}

--- a/environmentconfig.yaml
+++ b/environmentconfig.yaml
@@ -1,0 +1,7 @@
+apiVersion: apiextensions.crossplane.io/v1alpha1 # Or v1beta1 in newer versions
+kind: EnvironmentConfig
+metadata:
+  name: test-environment-config
+data:
+  storage.region: us-west-2
+  storage.endpoint: https://my-endpoint.org

--- a/function.yaml
+++ b/function.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-environment-configs
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-environment-configs:v0.4.0
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-go-templating
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.10.0

--- a/xrd.yaml
+++ b/xrd.yaml
@@ -1,0 +1,26 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xstorages.epca.eo
+spec:
+  group: epca.eo
+  names:
+    kind: XStorage
+    plural: xstorages
+  claimNames:
+    kind: Storage
+    plural: storages
+  versions:
+    - name: v1beta1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                owner:
+                  type: string
+


### PR DESCRIPTION
This example shows how `EnvironmentConfigs` and `CompositeConnectionDetails` can be used to populate a `ConnectionSecret` with values from the `EnvironmentConfig` and from the secret that is already created by the `provider-minio` with `writeConnectionSecretToRef`.