### PR TITLE
Add initial XRD design for XStorage/Storage

### DIFF
--- a/apis/xrd.yaml
+++ b/apis/xrd.yaml
@@ -85,7 +85,7 @@ spec:
                   description: Name of the `ProviderConfig` to use.
                   type: string
               required:
-                - userName
+                - owner
                 - buckets
                 - providerConfigRef
           required:

--- a/apis/xrd.yaml
+++ b/apis/xrd.yaml
@@ -1,5 +1,5 @@
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
 metadata:
   name: xstorages.epca.eo
 spec:

--- a/apis/xrd.yaml
+++ b/apis/xrd.yaml
@@ -1,0 +1,92 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: xstorages.epca.eo
+spec:
+  group: epca.eo
+  names:
+    kind: XStorage
+    plural: xstorages
+  claimNames:
+    kind: Storage
+    plural: storages
+  versions:
+    - name: v1beta1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                owner:
+                  description: Owner of the buckets to create.
+                  type: string
+                buckets:
+                  description: List of buckets to create and which are owned by the `owner`.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      bucketName:
+                        description: Name of the bucket to create.
+                        type: string
+                      discoverable:
+                        description: Whether this bucket should be discoverable through the catalog by other `owners` (defined in separate `Storage` claims).
+                        type: boolean
+                        default: false
+                    required:
+                      - bucketName
+                bucketAccessRequests:
+                  description: List of buckets where the `owner` requests either ReadWrite or ReadOnly permissions from other `owners` (defined in separate `Storage` claims).
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      bucketName:
+                        description: Name of the bucket to request permissions to.
+                        type: string
+                      permission:
+                        description: Permission that is requested.
+                        type: string
+                        enum:
+                          - ReadWrite
+                          - ReadOnly
+                    required:
+                      - bucketName
+                      - permission
+                bucketAccessGrants:
+                  description: List of buckets where the `owner` grants either ReadWrite or ReadOnly permissions to other `owners` (defined in separate `Storage` claims).
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      bucketName:
+                        description: Name of the bucket to grant permissions to.
+                        type: string
+                      permission:
+                        description: Permission that is granted.
+                        type: string
+                        enum:
+                          - ReadWrite
+                          - ReadOnly
+                      grantees:
+                        description: List of `owners` (defined in separate `Storage` claims) that the permission is granted to.
+                        type: array
+                        items:
+                          type: string
+                    required:
+                      - bucketName
+                      - permission
+                      - grantees
+                providerConfigRef:
+                  description: Name of the `ProviderConfig` to use.
+                  type: string
+              required:
+                - userName
+                - buckets
+                - providerConfigRef
+          required:
+            - spec

--- a/xrd.yaml
+++ b/xrd.yaml
@@ -81,12 +81,8 @@ spec:
                       - bucketName
                       - permission
                       - grantees
-                providerConfigRef:
-                  description: Name of the `ProviderConfig` to use.
-                  type: string
               required:
                 - owner
                 - buckets
-                - providerConfigRef
           required:
             - spec


### PR DESCRIPTION
This XRD design defines a global `owner` of `buckets` to be created. In addition, those `buckets` can be `discoverable` which can be used to create a catalog of buckets that other owners can request access to.

Furthermore, the `bucketAccessRequests` lets the `owner` define `buckets` which they want to request either `ReadWrite` or `ReadOnly` access to.

Lastly, the `bucketAccessGrants` lets the `owner` grant `ReadWrite` or `ReadOnly` access to `buckets` to other owners.

Closes #7.