### PR TITLE
Change group from epca.eo to pkg.internal

### DIFF
--- a/docs/how-to-guides/storage-minio.md
+++ b/docs/how-to-guides/storage-minio.md
@@ -158,10 +158,10 @@ This is everything that is needed for the `storage-minio` configuration package 
 
 ### How to create `Buckets` with `storage-minio`
 
-In order to create buckets you need to specify the `owner` and the `bucketName`. Additionally, you can set the flag `discoverable` to true which adds an annotation `xstorages.epca.eo/discoverable` to the bucket resource.
+In order to create buckets you need to specify the `owner` and the `bucketName`. Additionally, you can set the flag `discoverable` to true which adds an annotation `xstorages.pkg.internal/discoverable` to the bucket resource.
 
 ```yaml
-apiVersion: epca.eo/v1beta1
+apiVersion: pkg.internal/v1beta1
 kind: Storage
 metadata:
   name: <name>
@@ -179,7 +179,7 @@ spec:
 If an `owner` wants to request access to a bucket from another `owner` it can just be added to a claim by specifying the `bucketAccessRequests`. The permission can either be `ReadWrite` or `ReadOnly`.
 
 ```yaml
-apiVersion: epca.eo/v1beta1
+apiVersion: pkg.internal/v1beta1
 kind: Storage
 metadata:
   name: <name>
@@ -202,7 +202,7 @@ If access is granted to the bucket, the policy is created and attached to the `U
 It is possible to grant `owners` access to a bucket without them first requesting access. However, it is only attached to the user role if the user has requested access to it as well. Similarly to the requests, the claim can include `bucketAccessGrants` that grant permissions (`ReadWrite` or `ReadOnly`) to a bucket to a list of `grantees`.
 
 ```yaml
-apiVersion: epca.eo/v1beta1
+apiVersion: pkg.internal/v1beta1
 kind: Storage
 metadata:
   name: <name>

--- a/docs/tutorials/storage-minio.md
+++ b/docs/tutorials/storage-minio.md
@@ -301,7 +301,7 @@ Everything is up and running and we can create our first claim - or rather, our 
 # claims.yaml
 
 ---
-apiVersion: epca.eo/v1beta1
+apiVersion: pkg.internal/v1beta1
 kind: Storage
 metadata:
   name: alice
@@ -311,7 +311,7 @@ spec:
     - bucketName: alice
     - bucketName: alice-shared
 ---
-apiVersion: epca.eo/v1beta1
+apiVersion: pkg.internal/v1beta1
 kind: Storage
 metadata:
   name: bob
@@ -334,7 +334,7 @@ Now that everyone has their buckets, Alice wants to have access to `bob-shared` 
 # claims.yaml
 
 ---
-apiVersion: epca.eo/v1beta1
+apiVersion: pkg.internal/v1beta1
 kind: Storage
 metadata:
   name: alice
@@ -347,7 +347,7 @@ spec:
     - bucketName: bob-shared
       permission: ReadWrite
 ---
-apiVersion: epca.eo/v1beta1
+apiVersion: pkg.internal/v1beta1
 kind: Storage
 metadata:
   name: bob
@@ -395,7 +395,7 @@ Bob is the `owner` of `bob-shared` so he needs to grant Alice the `ReadWrite` pe
 # claims.yaml
 
 ---
-apiVersion: epca.eo/v1beta1
+apiVersion: pkg.internal/v1beta1
 kind: Storage
 metadata:
   name: alice
@@ -408,7 +408,7 @@ spec:
     - bucketName: bob-shared
       permission: ReadWrite
 ---
-apiVersion: epca.eo/v1beta1
+apiVersion: pkg.internal/v1beta1
 kind: Storage
 metadata:
   name: bob

--- a/minio/composition.yaml
+++ b/minio/composition.yaml
@@ -6,7 +6,7 @@ metadata:
     storage: minio
 spec:
   compositeTypeRef:
-    apiVersion: epca.eo/v1beta1
+    apiVersion: pkg.internal/v1beta1
     kind: XStorage
   mode: Pipeline
   pipeline:
@@ -28,7 +28,7 @@ spec:
               name: {{ $bucket.bucketName }}
               annotations:
                 gotemplating.fn.crossplane.io/composition-resource-name: bucket-{{ $owner }}-{{ $bucket.bucketName }}
-                xstorages.epca.eo/discoverable: "{{ printf "%t" $bucket.discoverable }}"
+                xstorages.pkg.internal/discoverable: "{{ printf "%t" $bucket.discoverable }}"
             spec:
               providerConfigRef:
                 name: storage-minio

--- a/xrd.yaml
+++ b/xrd.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xstorages.epca.eo
+  name: xstorages.pkg.internal
 spec:
-  group: epca.eo
+  group: pkg.internal
   names:
     kind: XStorage
     plural: xstorages


### PR DESCRIPTION
This change reflects the fact that provider-storage is a standalone configuration package independent from the building blocks of EOEPCA.

Closes #18.