### PR TITLE
Replace xpkg.upbound.io with xpkg.crossplane.io

### DIFF
--- a/docs/how-to-guides/storage-minio.md
+++ b/docs/how-to-guides/storage-minio.md
@@ -130,7 +130,7 @@ kind: Provider
 metadata:
   name: <name>
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:<version>
+  package: xpkg.crossplane.io/crossplane-contrib/provider-kubernetes:<version>
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig

--- a/docs/tutorials/storage-minio.md
+++ b/docs/tutorials/storage-minio.md
@@ -263,7 +263,7 @@ kind: Provider
 metadata:
   name: crossplane-contrib-provider-kubernetes
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.18.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-kubernetes:v0.18.0
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig

--- a/minio/crossplane.yaml
+++ b/minio/crossplane.yaml
@@ -16,15 +16,15 @@ spec:
       version: ">=v0.4.4"
     - apiVersion: pkg.crossplane.io/v1
       kind: Provider
-      package: xpkg.upbound.io/crossplane-contrib/provider-kubernetes
+      package: xpkg.crossplane.io/crossplane-contrib/provider-kubernetes
       version: ">=v0.18.0"
     - apiVersion: pkg.crossplane.io/v1
       kind: Function
-      package: xpkg.upbound.io/crossplane-contrib/function-auto-ready
+      package: xpkg.crossplane.io/crossplane-contrib/function-auto-ready
       version: ">=v0.5.0"
     - apiVersion: pkg.crossplane.io/v1
       kind: Function
-      package: xpkg.upbound.io/crossplane-contrib/function-go-templating
+      package: xpkg.crossplane.io/crossplane-contrib/function-go-templating
       version: ">=v0.10.0"
   crossplane:
     version: ">=v1.20.0"


### PR DESCRIPTION
Since Crossplane Version 2.0 the xpkg.upbound.io/crossplane-contrib/ repository has changed and seems to need a license from Upbound now. The OSS versions of all providers and functions are placed in xpkg.crossplane.io/crossplane-contrib/.

Closes #27.