### PR TITLE
Replace hardcoded configuration version with placeholder

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -55,6 +55,9 @@ jobs:
           sed -i 's/CompositeResourceDefinition/CustomResourceDefinition/' xrd.yaml
           sed -i 's/apiextensions.crossplane.io\/v1/apiextensions.k8s.io\/v1/g' xrd.yaml 
           crdoc -r xrd.yaml -o docs/reference-guides/api.md
+      - name: Replace Crossplane Configuration version with tag
+        run: |
+          find docs -type f -name "*.md" -exec sed -i "s/<!version!>/${{ github.ref_name }}/g" {} +
       - name: Set up GitHub Actions user
         run: |
           git config --global user.name "GitHub Actions"

--- a/docs/how-to-guides/storage-minio.md
+++ b/docs/how-to-guides/storage-minio.md
@@ -19,7 +19,7 @@ kind: Configuration
 metadata:
   name: storage-minio
 spec:
-  package: ghcr.io/versioneer-tech/provider-storage:v0.1-minio
+  package: ghcr.io/versioneer-tech/provider-storage:<!version!>-minio
 ```
 
 This automatically installs the necessary dependencies:

--- a/docs/tutorials/storage-minio.md
+++ b/docs/tutorials/storage-minio.md
@@ -83,7 +83,7 @@ kind: Configuration
 metadata:
   name: storage-minio
 spec:
-  package: ghcr.io/versioneer-tech/provider-storage:v0.1-minio
+  package: ghcr.io/versioneer-tech/provider-storage:<!version!>-minio
 ```
 
 Then, we need to apply it to the cluster with


### PR DESCRIPTION
The placeholder is replaced in the GitHub Action when a new tag is pushed and replaces it with the tag. In this way the docs are easier to maintain and the version is always up to date in the tutorials and how-to guides.

Closes #26.