### PR TITLE
Add --version flag to Crossplane Helm install

### DIFF
--- a/docs/tutorials/storage-minio.md
+++ b/docs/tutorials/storage-minio.md
@@ -27,7 +27,8 @@ helm repo add crossplane-stable https://charts.crossplane.io/stable
 helm repo update
 helm install crossplane \
 --namespace crossplane-system \
---create-namespace crossplane-stable/crossplane
+--create-namespace crossplane-stable/crossplane \
+--version 1.20.0
 ```
 
 ### MinIO installation


### PR DESCRIPTION
Since Crossplane has been updated to Version 2.0, the stable channel points to this version and so we needed to specify it in order for the tutorial to work.

Closes #25.