### PR TITLE
Port storage-minio to Crossplane v2.0

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,7 +26,7 @@ jobs:
           password: ${{ github.token }}
       - name: Install Crossplane CLI
         run: |
-          curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | sh
+          curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_VERSION=v2.0.2 sh
           sudo mv crossplane /usr/local/bin
       - name: Build and publish storage-minio Configuration Package
         run: |
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Crossplane CLI
         run: |
-          curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_VERSION=v1.20.0 sh
+          curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_VERSION=v2.0.2 sh
           sudo mv crossplane /usr/local/bin
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@main
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Crossplane CLI
         run: |
-          curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | sh
+          curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_VERSION=v2.0.2 sh
           sudo mv crossplane /usr/local/bin
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@main

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -104,6 +104,11 @@ jobs:
       - name: Run e2e tests
         run: |
           uptest e2e --setup-script minio/tests/e2e.bash examples/buckets.yaml
+      - name: Delete Configuration Package
+        run: |
+          echo "${{ github.token }}" | gh auth login --with-token
+          package_id=$(gh api /orgs/versioneer-tech/packages/container/provider-storage/versions | jq --arg PR_SLUG "${PR_SLUG}" -r '.[] | select(.metadata.container.tags | contains(["\($PR_SLUG)-minio"])) | .id')
+          gh api --method DELETE --silent "/orgs/versioneer-tech/packages/container/provider-storage/versions/${package_id}"
   aws_e2e_tests:
     runs-on: ubuntu-latest
     permissions:

--- a/minio/crossplane.yaml
+++ b/minio/crossplane.yaml
@@ -27,4 +27,4 @@ spec:
       package: xpkg.crossplane.io/crossplane-contrib/function-go-templating
       version: ">=v0.10.0"
   crossplane:
-    version: ">=v1.20.0"
+    version: ">=v2.0.2"

--- a/minio/tests/e2e.bash
+++ b/minio/tests/e2e.bash
@@ -60,7 +60,7 @@ kind: Configuration
 metadata:
   name: storage-minio
 spec:
-  package: ghcr.io/chrstphfrtz/testeroni-meloni/test:test-minio
+  package: ghcr.io/versioneer-tech/provider-storage:${PR_SLUG}-minio
 EOF
 
 # Wait for the configuration and providers to be healthy

--- a/minio/tests/e2e.bash
+++ b/minio/tests/e2e.bash
@@ -9,7 +9,8 @@ helm repo update
 helm install crossplane \
 --namespace crossplane-system \
 --create-namespace crossplane-stable/crossplane \
---version 1.20.0 \
+--version 2.0.2 \
+--set provider.defaultActivations={} \
 --wait
 
 # Install the MinIO operator
@@ -38,6 +39,20 @@ helm install \
   minio-tenant minio-operator/tenant \
   --wait
 
+# Install the MRAP to reduce stress on the control plane
+kubectl apply -f - << EOF
+apiVersion: apiextensions.crossplane.io/v1alpha1
+kind: ManagedResourceActivationPolicy
+metadata:
+  name: storage-aws
+spec:
+  activate:
+  - buckets.minio.crossplane.io
+  - policies.minio.crossplane.io
+  - users.minio.crossplane.io
+  - objects.kubernetes.crossplane.io
+EOF
+
 # Install the storage-minio configuration package
 kubectl apply -f - << EOF
 apiVersion: pkg.crossplane.io/v1
@@ -45,7 +60,7 @@ kind: Configuration
 metadata:
   name: storage-minio
 spec:
-  package: ghcr.io/versioneer-tech/provider-storage:${PR_SLUG}-minio
+  package: ghcr.io/chrstphfrtz/testeroni-meloni/test:test-minio
 EOF
 
 # Wait for the configuration and providers to be healthy

--- a/minio/tests/expected/001-buckets.yaml
+++ b/minio/tests/expected/001-buckets.yaml
@@ -28,7 +28,6 @@ metadata:
   annotations:
     crossplane.io/composition-resource-name: bucket-alice-001-alice-001
     xstorages.pkg.internal/discoverable: "false"
-  generateName: alice-001-
   labels:
     crossplane.io/composite: alice-001
   name: alice-001
@@ -49,7 +48,6 @@ metadata:
   annotations:
     crossplane.io/composition-resource-name: bucket-alice-001-alice-shared-001
     xstorages.pkg.internal/discoverable: "true"
-  generateName: alice-001-
   labels:
     crossplane.io/composite: alice-001
   name: alice-shared-001
@@ -69,7 +67,6 @@ kind: Policy
 metadata:
   annotations:
     crossplane.io/composition-resource-name: policy-alice-001.owner.alice-001
-  generateName: alice-001-
   labels:
     crossplane.io/composite: alice-001
   name: alice-001.owner.alice-001
@@ -104,7 +101,6 @@ kind: Policy
 metadata:
   annotations:
     crossplane.io/composition-resource-name: policy-alice-001.owner.alice-shared-001
-  generateName: alice-001-
   labels:
     crossplane.io/composite: alice-001
   name: alice-001.owner.alice-shared-001
@@ -139,7 +135,6 @@ kind: User
 metadata:
   annotations:
     crossplane.io/composition-resource-name: user-alice-001
-  generateName: alice-001-
   labels:
     crossplane.io/composite: alice-001
   name: alice-001

--- a/minio/tests/expected/003-buckets.yaml
+++ b/minio/tests/expected/003-buckets.yaml
@@ -69,7 +69,6 @@ kind: Object
 metadata:
   annotations:
     crossplane.io/composition-resource-name: check-policy-alice-003.readwrite.bob-shared-003
-  generateName: alice-003-
   labels:
     crossplane.io/composite: alice-003
   name: policy-observer-alice-003.readwrite.bob-shared-003

--- a/minio/tests/expected/005-buckets.yaml
+++ b/minio/tests/expected/005-buckets.yaml
@@ -33,7 +33,6 @@ metadata:
   annotations:
     crossplane.io/composition-resource-name: bucket-alice-005-alice-005
     xstorages.pkg.internal/discoverable: "false"
-  generateName: alice-005-
   labels:
     crossplane.io/composite: alice-005
   name: alice-005
@@ -54,7 +53,6 @@ metadata:
   annotations:
     crossplane.io/composition-resource-name: bucket-alice-005-alice-shared-005
     xstorages.pkg.internal/discoverable: "true"
-  generateName: alice-005-
   labels:
     crossplane.io/composite: alice-005
   name: alice-shared-005
@@ -74,7 +72,6 @@ kind: Policy
 metadata:
   annotations:
     crossplane.io/composition-resource-name: policy-alice-005.owner.alice-005
-  generateName: alice-005-
   labels:
     crossplane.io/composite: alice-005
   name: alice-005.owner.alice-005
@@ -109,7 +106,6 @@ kind: Policy
 metadata:
   annotations:
     crossplane.io/composition-resource-name: policy-alice-005.owner.alice-shared-005
-  generateName: alice-005-
   labels:
     crossplane.io/composite: alice-005
   name: alice-005.owner.alice-shared-005
@@ -144,7 +140,6 @@ kind: Policy
 metadata:
   annotations:
     crossplane.io/composition-resource-name: policy-bob-005.readonly.alice-shared-005
-  generateName: alice-005-
   labels:
     crossplane.io/composite: alice-005
   name: bob-005.readonly.alice-shared-005
@@ -190,7 +185,6 @@ kind: User
 metadata:
   annotations:
     crossplane.io/composition-resource-name: user-alice-005
-  generateName: alice-005-
   labels:
     crossplane.io/composite: alice-005
   name: alice-005


### PR DESCRIPTION
storage-minio is now tested against Crossplane v2.0.2 and the Crossplane dependency has been updated to this version as well.

Closes #35.