### PR TITLE
Fix GitHub workflow: tag.yaml

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -20,14 +20,18 @@ jobs:
           password: ${{ github.token }}
       - name: Install Crossplane CLI
         run: |
-          curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh" | sh
+          curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_VERSION=v2.0.2 sh
           sudo mv crossplane /usr/local/bin
       - name: Build and publish storage-minio Configuration Package
         run: |
           cp xrd.yaml minio/xrd.yaml
-          cd minio/
-          crossplane xpkg build --package-root=. --ignore="examples/*,tests/*,tests/expected/*,tests/observed/*" --verbose
-          crossplane xpkg push "ghcr.io/versioneer-tech/provider-storage:${{ github.ref_name }}-minio" --domain="https://ghcr.io" --verbose
+          crossplane xpkg build --package-root=minio --ignore="tests/observed/*,tests/expected/*" --package-file=minio/storage-minio.xpkg --verbose
+          crossplane xpkg push --package-files=minio/storage-minio.xpkg "ghcr.io/versioneer-tech/provider-storage:${{ github.ref_name }}-minio" --verbose
+      - name: Build and publish storage-aws Configuration Package
+        run: |
+          cp xrd.yaml aws/xrd.yaml
+          crossplane xpkg build --package-root=aws --ignore="tests/observed/*,tests/expected/*" --package-file=aws/storage-aws.xpkg --verbose
+          crossplane xpkg push --package-files=aws/storage-aws.xpkg "ghcr.io/versioneer-tech/provider-storage:${{ github.ref_name }}-aws" --verbose
   build_docs:
     runs-on: ubuntu-latest
     needs: build_and_publish_configuration_packages


### PR DESCRIPTION
The crossplane CLI command was not updated for Crossplane v2.0 and used old flags. Furthermore, storage-aws was not built and pushed.

Closes #37.