### PR TITLE
Ignore required resources for storage-aws

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Build and publish storage-aws Configuration Package
         run: |
           cp xrd.yaml aws/xrd.yaml
-          crossplane xpkg build --package-root=aws --ignore="tests/observed/*,tests/expected/*" --package-file=aws/storage-aws.xpkg --verbose
+          crossplane xpkg build --package-root=aws --ignore="tests/observed/*,tests/expected/*,tests/required/*" --package-file=aws/storage-aws.xpkg --verbose
           crossplane xpkg push --package-files=aws/storage-aws.xpkg "ghcr.io/versioneer-tech/provider-storage:${{ github.ref_name }}-aws" --verbose
   build_docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The build step in the tag workflow failed because the newly created yaml files in the aws/tests/required/ directory needed to be ignored.

Closes #43.