### PR TITLE
Add second user for MinIO and cred rotation CronJob

### DIFF
--- a/aws/composition.yaml
+++ b/aws/composition.yaml
@@ -326,21 +326,23 @@ spec:
               spec = xr.get("spec", {}) or {}
               ns   = (meta.get("labels", {}) or {}).get("crossplane.io/claim-namespace") or meta.get("namespace") or "default"
               principal = (spec.get("principal") or meta.get("name") or "<principal>").strip()
-              key = f"access-key-{principal}"
-              rsp.desired.resources[key].resource.update({
-                  "apiVersion": "iam.aws.m.upbound.io/v1beta1",
-                  "kind": "AccessKey",
-                  "metadata": {
-                      "name": principal,
-                      "namespace": ns,
-                      "annotations": {"crossplane.io/composition-resource-name": key}
-                  },
-                  "spec": {
-                      "forProvider": {"userRef": {"name": principal}},
-                      "providerConfigRef": {"name": "provider-aws", "kind": "ProviderConfig"},
-                      "writeConnectionSecretToRef": {"name": principal}
-                  }
-              })
+
+              for i in range(2):
+                  key = f"access-key-{principal}-{i+1}"
+                  rsp.desired.resources[key].resource.update({
+                      "apiVersion": "iam.aws.m.upbound.io/v1beta1",
+                      "kind": "AccessKey",
+                      "metadata": {
+                          "name": f"{principal}-{i+1}",
+                          "namespace": ns,
+                          "annotations": {"crossplane.io/composition-resource-name": key}
+                      },
+                      "spec": {
+                          "forProvider": {"userRef": {"name": principal}},
+                          "providerConfigRef": {"name": "provider-aws", "kind": "ProviderConfig"},
+                          "writeConnectionSecretToRef": {"name": f"{principal}-{i+1}"}
+                      }
+                  })
 
     - step: automatically-detect-ready-composed-resources
       functionRef:

--- a/aws/tests/001-buckets.yaml
+++ b/aws/tests/001-buckets.yaml
@@ -1,6 +1,3 @@
-# Copyright 2025, EOX (https://eox.at) and Versioneer (https://versioneer.at)
-# SPDX-License-Identifier: Apache-2.0
-
 ---
 apiVersion: pkg.internal/v1beta1
 kind: Storage
@@ -23,8 +20,8 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2024-01-01T00:00:00Z"
-    message: 'Unready resources: access-key-joe, bucket-s-joe, observe-joe-s-jeff-shared,
-      and 4 more'
+    message: 'Unready resources: access-key-joe-1, access-key-joe-2, bucket-s-joe,
+      and 5 more'
     reason: Creating
     status: "False"
     type: Ready
@@ -33,10 +30,10 @@ apiVersion: iam.aws.m.upbound.io/v1beta1
 kind: AccessKey
 metadata:
   annotations:
-    crossplane.io/composition-resource-name: access-key-joe
+    crossplane.io/composition-resource-name: access-key-joe-1
   labels:
     crossplane.io/composite: s-joe
-  name: joe
+  name: joe-1
   namespace: default
   ownerReferences:
   - apiVersion: pkg.internal/v1beta1
@@ -53,7 +50,33 @@ spec:
     kind: ProviderConfig
     name: provider-aws
   writeConnectionSecretToRef:
-    name: joe
+    name: joe-1
+---
+apiVersion: iam.aws.m.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: access-key-joe-2
+  labels:
+    crossplane.io/composite: s-joe
+  name: joe-2
+  namespace: default
+  ownerReferences:
+  - apiVersion: pkg.internal/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Storage
+    name: s-joe
+    uid: ""
+spec:
+  forProvider:
+    userRef:
+      name: joe
+  providerConfigRef:
+    kind: ProviderConfig
+    name: provider-aws
+  writeConnectionSecretToRef:
+    name: joe-2
 ---
 apiVersion: s3.aws.m.upbound.io/v1beta1
 kind: Bucket

--- a/aws/tests/001x-buckets.yaml
+++ b/aws/tests/001x-buckets.yaml
@@ -1,6 +1,3 @@
-# Copyright 2025, EOX (https://eox.at) and Versioneer (https://versioneer.at)
-# SPDX-License-Identifier: Apache-2.0
-
 ---
 apiVersion: pkg.internal/v1beta1
 kind: Storage
@@ -23,8 +20,8 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2024-01-01T00:00:00Z"
-    message: 'Unready resources: access-key-joe, bucket-s-joe, observe-joe-s-jeff-shared,
-      and 4 more'
+    message: 'Unready resources: access-key-joe-1, access-key-joe-2, bucket-s-joe,
+      and 5 more'
     reason: Creating
     status: "False"
     type: Ready
@@ -33,10 +30,10 @@ apiVersion: iam.aws.m.upbound.io/v1beta1
 kind: AccessKey
 metadata:
   annotations:
-    crossplane.io/composition-resource-name: access-key-joe
+    crossplane.io/composition-resource-name: access-key-joe-1
   labels:
     crossplane.io/composite: s-joe
-  name: joe
+  name: joe-1
   namespace: default
   ownerReferences:
   - apiVersion: pkg.internal/v1beta1
@@ -53,7 +50,33 @@ spec:
     kind: ProviderConfig
     name: provider-aws
   writeConnectionSecretToRef:
-    name: joe
+    name: joe-1
+---
+apiVersion: iam.aws.m.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: access-key-joe-2
+  labels:
+    crossplane.io/composite: s-joe
+  name: joe-2
+  namespace: default
+  ownerReferences:
+  - apiVersion: pkg.internal/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Storage
+    name: s-joe
+    uid: ""
+spec:
+  forProvider:
+    userRef:
+      name: joe
+  providerConfigRef:
+    kind: ProviderConfig
+    name: provider-aws
+  writeConnectionSecretToRef:
+    name: joe-2
 ---
 apiVersion: s3.aws.m.upbound.io/v1beta1
 kind: Bucket

--- a/aws/tests/002-buckets.yaml
+++ b/aws/tests/002-buckets.yaml
@@ -1,6 +1,3 @@
-# Copyright 2025, EOX (https://eox.at) and Versioneer (https://versioneer.at)
-# SPDX-License-Identifier: Apache-2.0
-
 ---
 apiVersion: pkg.internal/v1beta1
 kind: Storage
@@ -24,8 +21,8 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2024-01-01T00:00:00Z"
-    message: 'Unready resources: access-key-jeff, bucket-s-jeff, bucket-s-jeff-shared,
-      and 7 more'
+    message: 'Unready resources: access-key-jeff-1, access-key-jeff-2, bucket-s-jeff,
+      and 8 more'
     reason: Creating
     status: "False"
     type: Ready
@@ -34,10 +31,10 @@ apiVersion: iam.aws.m.upbound.io/v1beta1
 kind: AccessKey
 metadata:
   annotations:
-    crossplane.io/composition-resource-name: access-key-jeff
+    crossplane.io/composition-resource-name: access-key-jeff-1
   labels:
     crossplane.io/composite: s-jeff
-  name: jeff
+  name: jeff-1
   namespace: default
   ownerReferences:
   - apiVersion: pkg.internal/v1beta1
@@ -54,7 +51,33 @@ spec:
     kind: ProviderConfig
     name: provider-aws
   writeConnectionSecretToRef:
-    name: jeff
+    name: jeff-1
+---
+apiVersion: iam.aws.m.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: access-key-jeff-2
+  labels:
+    crossplane.io/composite: s-jeff
+  name: jeff-2
+  namespace: default
+  ownerReferences:
+  - apiVersion: pkg.internal/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Storage
+    name: s-jeff
+    uid: ""
+spec:
+  forProvider:
+    userRef:
+      name: jeff
+  providerConfigRef:
+    kind: ProviderConfig
+    name: provider-aws
+  writeConnectionSecretToRef:
+    name: jeff-2
 ---
 apiVersion: s3.aws.m.upbound.io/v1beta1
 kind: Bucket

--- a/aws/tests/003-buckets.yaml
+++ b/aws/tests/003-buckets.yaml
@@ -1,6 +1,3 @@
-# Copyright 2025, EOX (https://eox.at) and Versioneer (https://versioneer.at)
-# SPDX-License-Identifier: Apache-2.0
-
 ---
 apiVersion: pkg.internal/v1beta1
 kind: Storage
@@ -16,7 +13,8 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2024-01-01T00:00:00Z"
-    message: 'Unready resources: access-key-jane, observe-jane-s-john, and user-jane'
+    message: 'Unready resources: access-key-jane-1, access-key-jane-2, observe-jane-s-john,
+      and 1 more'
     reason: Creating
     status: "False"
     type: Ready
@@ -25,10 +23,10 @@ apiVersion: iam.aws.m.upbound.io/v1beta1
 kind: AccessKey
 metadata:
   annotations:
-    crossplane.io/composition-resource-name: access-key-jane
+    crossplane.io/composition-resource-name: access-key-jane-1
   labels:
     crossplane.io/composite: s-jane
-  name: jane
+  name: jane-1
   namespace: default
   ownerReferences:
   - apiVersion: pkg.internal/v1beta1
@@ -45,7 +43,33 @@ spec:
     kind: ProviderConfig
     name: provider-aws
   writeConnectionSecretToRef:
-    name: jane
+    name: jane-1
+---
+apiVersion: iam.aws.m.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: access-key-jane-2
+  labels:
+    crossplane.io/composite: s-jane
+  name: jane-2
+  namespace: default
+  ownerReferences:
+  - apiVersion: pkg.internal/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Storage
+    name: s-jane
+    uid: ""
+spec:
+  forProvider:
+    userRef:
+      name: jane
+  providerConfigRef:
+    kind: ProviderConfig
+    name: provider-aws
+  writeConnectionSecretToRef:
+    name: jane-2
 ---
 apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: Object

--- a/aws/tests/004-buckets.yaml
+++ b/aws/tests/004-buckets.yaml
@@ -1,6 +1,3 @@
-# Copyright 2025, EOX (https://eox.at) and Versioneer (https://versioneer.at)
-# SPDX-License-Identifier: Apache-2.0
-
 ---
 apiVersion: pkg.internal/v1beta1
 kind: Storage
@@ -29,8 +26,8 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2024-01-01T00:00:00Z"
-    message: 'Unready resources: access-key-john, bucket-s-john, observe-john-s-jane,
-      and 6 more'
+    message: 'Unready resources: access-key-john-1, access-key-john-2, bucket-s-john,
+      and 7 more'
     reason: Creating
     status: "False"
     type: Ready
@@ -39,10 +36,10 @@ apiVersion: iam.aws.m.upbound.io/v1beta1
 kind: AccessKey
 metadata:
   annotations:
-    crossplane.io/composition-resource-name: access-key-john
+    crossplane.io/composition-resource-name: access-key-john-1
   labels:
     crossplane.io/composite: s-john
-  name: john
+  name: john-1
   namespace: default
   ownerReferences:
   - apiVersion: pkg.internal/v1beta1
@@ -59,7 +56,33 @@ spec:
     kind: ProviderConfig
     name: provider-aws
   writeConnectionSecretToRef:
-    name: john
+    name: john-1
+---
+apiVersion: iam.aws.m.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: access-key-john-2
+  labels:
+    crossplane.io/composite: s-john
+  name: john-2
+  namespace: default
+  ownerReferences:
+  - apiVersion: pkg.internal/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Storage
+    name: s-john
+    uid: ""
+spec:
+  forProvider:
+    userRef:
+      name: john
+  providerConfigRef:
+    kind: ProviderConfig
+    name: provider-aws
+  writeConnectionSecretToRef:
+    name: john-2
 ---
 apiVersion: s3.aws.m.upbound.io/v1beta1
 kind: Bucket

--- a/aws/tests/expected/001-buckets.yaml
+++ b/aws/tests/expected/001-buckets.yaml
@@ -8,43 +8,42 @@ metadata:
   name: s-joe
 spec:
   bucketAccessGrants:
-  - bucketName: s-joe
-    grantedAt: "2025-09-29T10:05:00Z"
-    grantee: jeff
-    permission: ReadWrite
+    - bucketName: s-joe
+      grantedAt: "2025-09-29T10:05:00Z"
+      grantee: jeff
+      permission: ReadWrite
   bucketAccessRequests:
-  - bucketName: s-jeff-shared
-    reason: Need access
-    requestedAt: "2025-09-29T10:00:00Z"
+    - bucketName: s-jeff-shared
+      reason: Need access
+      requestedAt: "2025-09-29T10:00:00Z"
   buckets:
-  - bucketName: s-joe
-    discoverable: true
+    - bucketName: s-joe
+      discoverable: true
   principal: joe
 status:
   conditions:
-  - lastTransitionTime: "2024-01-01T00:00:00Z"
-    message: 'Unready resources: access-key-joe, bucket-s-joe, observe-joe-s-jeff-shared,
-      and 4 more'
-    reason: Creating
-    status: "False"
-    type: Ready
+    - lastTransitionTime: "2024-01-01T00:00:00Z"
+      message: "Unready resources: access-key-joe-1, access-key-joe-2, bucket-s-joe, and 5 more"
+      reason: Creating
+      status: "False"
+      type: Ready
 ---
 apiVersion: iam.aws.m.upbound.io/v1beta1
 kind: AccessKey
 metadata:
   annotations:
-    crossplane.io/composition-resource-name: access-key-joe
+    crossplane.io/composition-resource-name: access-key-joe-1
   labels:
     crossplane.io/composite: s-joe
-  name: joe
+  name: joe-1
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     userRef:
@@ -53,7 +52,33 @@ spec:
     kind: ProviderConfig
     name: provider-aws
   writeConnectionSecretToRef:
-    name: joe
+    name: joe-1
+---
+apiVersion: iam.aws.m.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: access-key-joe-2
+  labels:
+    crossplane.io/composite: s-joe
+  name: joe-2
+  namespace: default
+  ownerReferences:
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
+spec:
+  forProvider:
+    userRef:
+      name: joe
+  providerConfigRef:
+    kind: ProviderConfig
+    name: provider-aws
+  writeConnectionSecretToRef:
+    name: joe-2
 ---
 apiVersion: s3.aws.m.upbound.io/v1beta1
 kind: Bucket
@@ -65,12 +90,12 @@ metadata:
   name: s-joe
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     region: eu-central-1
@@ -88,12 +113,12 @@ metadata:
   name: observe-joe-s-jeff-shared
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -103,7 +128,7 @@ spec:
         name: joe.s-jeff-shared
         namespace: default
   managementPolicies:
-  - Observe
+    - Observe
   providerConfigRef:
     kind: ProviderConfig
     name: provider-kubernetes
@@ -118,12 +143,12 @@ metadata:
   name: jeff.s-joe
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     policy: |-
@@ -159,12 +184,12 @@ metadata:
   name: joe.s-joe
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     policy: |-
@@ -197,12 +222,12 @@ metadata:
   name: joe.s-joe
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     policyArnRef:
@@ -223,12 +248,12 @@ metadata:
   name: joe
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider: {}
   providerConfigRef:

--- a/aws/tests/expected/001x-buckets.yaml
+++ b/aws/tests/expected/001x-buckets.yaml
@@ -8,43 +8,42 @@ metadata:
   name: s-joe
 spec:
   bucketAccessGrants:
-  - bucketName: s-joe
-    grantedAt: "2025-09-29T10:05:00Z"
-    grantee: jeff
-    permission: ReadWrite
+    - bucketName: s-joe
+      grantedAt: "2025-09-29T10:05:00Z"
+      grantee: jeff
+      permission: ReadWrite
   bucketAccessRequests:
-  - bucketName: s-jeff-shared
-    reason: Need access
-    requestedAt: "2025-09-29T10:00:00Z"
+    - bucketName: s-jeff-shared
+      reason: Need access
+      requestedAt: "2025-09-29T10:00:00Z"
   buckets:
-  - bucketName: s-joe
-    discoverable: true
+    - bucketName: s-joe
+      discoverable: true
   principal: joe
 status:
   conditions:
-  - lastTransitionTime: "2024-01-01T00:00:00Z"
-    message: 'Unready resources: access-key-joe, bucket-s-joe, observe-joe-s-jeff-shared,
-      and 4 more'
-    reason: Creating
-    status: "False"
-    type: Ready
+    - lastTransitionTime: "2024-01-01T00:00:00Z"
+      message: "Unready resources: access-key-joe-1, access-key-joe-2, bucket-s-joe, and 5 more"
+      reason: Creating
+      status: "False"
+      type: Ready
 ---
 apiVersion: iam.aws.m.upbound.io/v1beta1
 kind: AccessKey
 metadata:
   annotations:
-    crossplane.io/composition-resource-name: access-key-joe
+    crossplane.io/composition-resource-name: access-key-joe-1
   labels:
     crossplane.io/composite: s-joe
-  name: joe
+  name: joe-1
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     userRef:
@@ -53,7 +52,33 @@ spec:
     kind: ProviderConfig
     name: provider-aws
   writeConnectionSecretToRef:
-    name: joe
+    name: joe-1
+---
+apiVersion: iam.aws.m.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: access-key-joe-2
+  labels:
+    crossplane.io/composite: s-joe
+  name: joe-2
+  namespace: default
+  ownerReferences:
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
+spec:
+  forProvider:
+    userRef:
+      name: joe
+  providerConfigRef:
+    kind: ProviderConfig
+    name: provider-aws
+  writeConnectionSecretToRef:
+    name: joe-2
 ---
 apiVersion: s3.aws.m.upbound.io/v1beta1
 kind: Bucket
@@ -65,12 +90,12 @@ metadata:
   name: s-joe
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     region: eu-central-1
@@ -88,12 +113,12 @@ metadata:
   name: observe-joe-s-jeff-shared
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -103,7 +128,7 @@ spec:
         name: joe.s-jeff-shared
         namespace: default
   managementPolicies:
-  - Observe
+    - Observe
   providerConfigRef:
     kind: ProviderConfig
     name: provider-kubernetes
@@ -118,12 +143,12 @@ metadata:
   name: jeff.s-joe
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     policy: |-
@@ -159,12 +184,12 @@ metadata:
   name: joe.s-joe
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     policy: |-
@@ -197,12 +222,12 @@ metadata:
   name: joe.s-joe
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     policyArnRef:
@@ -223,12 +248,12 @@ metadata:
   name: joe
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider: {}
   providerConfigRef:

--- a/aws/tests/expected/002-buckets.yaml
+++ b/aws/tests/expected/002-buckets.yaml
@@ -8,44 +8,43 @@ metadata:
   name: s-jeff
 spec:
   bucketAccessGrants:
-  - bucketName: s-jeff-shared
-    grantedAt: "2025-09-29T10:15:00Z"
-    grantee: joe
-    permission: ReadOnly
+    - bucketName: s-jeff-shared
+      grantedAt: "2025-09-29T10:15:00Z"
+      grantee: joe
+      permission: ReadOnly
   bucketAccessRequests:
-  - bucketName: s-joe
-    reason: Need access
-    requestedAt: "2025-09-29T10:10:00Z"
+    - bucketName: s-joe
+      reason: Need access
+      requestedAt: "2025-09-29T10:10:00Z"
   buckets:
-  - bucketName: s-jeff
-  - bucketName: s-jeff-shared
-    discoverable: true
+    - bucketName: s-jeff
+    - bucketName: s-jeff-shared
+      discoverable: true
   principal: jeff
 status:
   conditions:
-  - lastTransitionTime: "2024-01-01T00:00:00Z"
-    message: 'Unready resources: access-key-jeff, bucket-s-jeff, bucket-s-jeff-shared,
-      and 7 more'
-    reason: Creating
-    status: "False"
-    type: Ready
+    - lastTransitionTime: "2024-01-01T00:00:00Z"
+      message: "Unready resources: access-key-jeff-1, access-key-jeff-2, bucket-s-jeff, and 8 more"
+      reason: Creating
+      status: "False"
+      type: Ready
 ---
 apiVersion: iam.aws.m.upbound.io/v1beta1
 kind: AccessKey
 metadata:
   annotations:
-    crossplane.io/composition-resource-name: access-key-jeff
+    crossplane.io/composition-resource-name: access-key-jeff-1
   labels:
     crossplane.io/composite: s-jeff
-  name: jeff
+  name: jeff-1
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jeff
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jeff
+      uid: ""
 spec:
   forProvider:
     userRef:
@@ -54,7 +53,33 @@ spec:
     kind: ProviderConfig
     name: provider-aws
   writeConnectionSecretToRef:
-    name: jeff
+    name: jeff-1
+---
+apiVersion: iam.aws.m.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: access-key-jeff-2
+  labels:
+    crossplane.io/composite: s-jeff
+  name: jeff-2
+  namespace: default
+  ownerReferences:
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jeff
+      uid: ""
+spec:
+  forProvider:
+    userRef:
+      name: jeff
+  providerConfigRef:
+    kind: ProviderConfig
+    name: provider-aws
+  writeConnectionSecretToRef:
+    name: jeff-2
 ---
 apiVersion: s3.aws.m.upbound.io/v1beta1
 kind: Bucket
@@ -66,12 +91,12 @@ metadata:
   name: s-jeff
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jeff
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jeff
+      uid: ""
 spec:
   forProvider:
     region: eu-central-1
@@ -89,12 +114,12 @@ metadata:
   name: s-jeff-shared
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jeff
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jeff
+      uid: ""
 spec:
   forProvider:
     region: eu-central-1
@@ -112,12 +137,12 @@ metadata:
   name: observe-jeff-s-joe
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jeff
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jeff
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -127,7 +152,7 @@ spec:
         name: jeff.s-joe
         namespace: default
   managementPolicies:
-  - Observe
+    - Observe
   providerConfigRef:
     kind: ProviderConfig
     name: provider-kubernetes
@@ -142,12 +167,12 @@ metadata:
   name: joe.s-jeff-shared
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jeff
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jeff
+      uid: ""
 spec:
   forProvider:
     policy: |-
@@ -188,12 +213,12 @@ metadata:
   name: jeff.s-jeff
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jeff
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jeff
+      uid: ""
 spec:
   forProvider:
     policy: |-
@@ -226,12 +251,12 @@ metadata:
   name: jeff.s-jeff-shared
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jeff
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jeff
+      uid: ""
 spec:
   forProvider:
     policy: |-
@@ -264,12 +289,12 @@ metadata:
   name: jeff.s-jeff
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jeff
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jeff
+      uid: ""
 spec:
   forProvider:
     policyArnRef:
@@ -290,12 +315,12 @@ metadata:
   name: jeff.s-jeff-shared
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jeff
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jeff
+      uid: ""
 spec:
   forProvider:
     policyArnRef:
@@ -316,12 +341,12 @@ metadata:
   name: jeff
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jeff
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jeff
+      uid: ""
 spec:
   forProvider: {}
   providerConfigRef:

--- a/aws/tests/expected/003-buckets.yaml
+++ b/aws/tests/expected/003-buckets.yaml
@@ -8,35 +8,35 @@ metadata:
   name: s-jane
 spec:
   bucketAccessRequests:
-  - bucketName: s-john
-    reason: Need WriteOnly access
-    requestedAt: "2025-09-29T10:20:00Z"
+    - bucketName: s-john
+      reason: Need WriteOnly access
+      requestedAt: "2025-09-29T10:20:00Z"
   buckets: []
   principal: jane
 status:
   conditions:
-  - lastTransitionTime: "2024-01-01T00:00:00Z"
-    message: 'Unready resources: access-key-jane, observe-jane-s-john, and user-jane'
-    reason: Creating
-    status: "False"
-    type: Ready
+    - lastTransitionTime: "2024-01-01T00:00:00Z"
+      message: "Unready resources: access-key-jane-1, access-key-jane-2, observe-jane-s-john, and 1 more"
+      reason: Creating
+      status: "False"
+      type: Ready
 ---
 apiVersion: iam.aws.m.upbound.io/v1beta1
 kind: AccessKey
 metadata:
   annotations:
-    crossplane.io/composition-resource-name: access-key-jane
+    crossplane.io/composition-resource-name: access-key-jane-1
   labels:
     crossplane.io/composite: s-jane
-  name: jane
+  name: jane-1
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jane
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jane
+      uid: ""
 spec:
   forProvider:
     userRef:
@@ -45,7 +45,33 @@ spec:
     kind: ProviderConfig
     name: provider-aws
   writeConnectionSecretToRef:
-    name: jane
+    name: jane-1
+---
+apiVersion: iam.aws.m.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: access-key-jane-2
+  labels:
+    crossplane.io/composite: s-jane
+  name: jane-2
+  namespace: default
+  ownerReferences:
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jane
+      uid: ""
+spec:
+  forProvider:
+    userRef:
+      name: jane
+  providerConfigRef:
+    kind: ProviderConfig
+    name: provider-aws
+  writeConnectionSecretToRef:
+    name: jane-2
 ---
 apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: Object
@@ -57,12 +83,12 @@ metadata:
   name: observe-jane-s-john
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jane
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jane
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -72,7 +98,7 @@ spec:
         name: jane.s-john
         namespace: default
   managementPolicies:
-  - Observe
+    - Observe
   providerConfigRef:
     kind: ProviderConfig
     name: provider-kubernetes
@@ -87,12 +113,12 @@ metadata:
   name: jane
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jane
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jane
+      uid: ""
 spec:
   forProvider: {}
   providerConfigRef:

--- a/aws/tests/expected/004-buckets.yaml
+++ b/aws/tests/expected/004-buckets.yaml
@@ -8,49 +8,48 @@ metadata:
   name: s-john
 spec:
   bucketAccessGrants:
-  - bucketName: s-john
-    grantedAt: "2025-09-29T10:28:00Z"
-    grantee: jane
-    permission: None
+    - bucketName: s-john
+      grantedAt: "2025-09-29T10:28:00Z"
+      grantee: jane
+      permission: None
   bucketAccessRequests:
-  - bucketName: s-joe
-    reason: Need access
-    requestedAt: "2025-09-29T10:25:00Z"
-  - bucketName: s-jeff
-    reason: Need access
-    requestedAt: "2025-09-29T10:26:00Z"
-  - bucketName: s-jane
-    reason: Need access
-    requestedAt: "2025-09-29T10:27:00Z"
+    - bucketName: s-joe
+      reason: Need access
+      requestedAt: "2025-09-29T10:25:00Z"
+    - bucketName: s-jeff
+      reason: Need access
+      requestedAt: "2025-09-29T10:26:00Z"
+    - bucketName: s-jane
+      reason: Need access
+      requestedAt: "2025-09-29T10:27:00Z"
   buckets:
-  - bucketName: s-john
-    discoverable: true
+    - bucketName: s-john
+      discoverable: true
   principal: john
 status:
   conditions:
-  - lastTransitionTime: "2024-01-01T00:00:00Z"
-    message: 'Unready resources: access-key-john, bucket-s-john, observe-john-s-jane,
-      and 6 more'
-    reason: Creating
-    status: "False"
-    type: Ready
+    - lastTransitionTime: "2024-01-01T00:00:00Z"
+      message: "Unready resources: access-key-john-1, access-key-john-2, bucket-s-john, and 7 more"
+      reason: Creating
+      status: "False"
+      type: Ready
 ---
 apiVersion: iam.aws.m.upbound.io/v1beta1
 kind: AccessKey
 metadata:
   annotations:
-    crossplane.io/composition-resource-name: access-key-john
+    crossplane.io/composition-resource-name: access-key-john-1
   labels:
     crossplane.io/composite: s-john
-  name: john
+  name: john-1
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-john
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-john
+      uid: ""
 spec:
   forProvider:
     userRef:
@@ -59,7 +58,33 @@ spec:
     kind: ProviderConfig
     name: provider-aws
   writeConnectionSecretToRef:
-    name: john
+    name: john-1
+---
+apiVersion: iam.aws.m.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: access-key-john-2
+  labels:
+    crossplane.io/composite: s-john
+  name: john-2
+  namespace: default
+  ownerReferences:
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-john
+      uid: ""
+spec:
+  forProvider:
+    userRef:
+      name: john
+  providerConfigRef:
+    kind: ProviderConfig
+    name: provider-aws
+  writeConnectionSecretToRef:
+    name: john-2
 ---
 apiVersion: s3.aws.m.upbound.io/v1beta1
 kind: Bucket
@@ -71,12 +96,12 @@ metadata:
   name: s-john
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-john
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-john
+      uid: ""
 spec:
   forProvider:
     region: eu-central-1
@@ -94,12 +119,12 @@ metadata:
   name: observe-john-s-jane
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-john
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-john
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -109,7 +134,7 @@ spec:
         name: john.s-jane
         namespace: default
   managementPolicies:
-  - Observe
+    - Observe
   providerConfigRef:
     kind: ProviderConfig
     name: provider-kubernetes
@@ -124,12 +149,12 @@ metadata:
   name: observe-john-s-jeff
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-john
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-john
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -139,7 +164,7 @@ spec:
         name: john.s-jeff
         namespace: default
   managementPolicies:
-  - Observe
+    - Observe
   providerConfigRef:
     kind: ProviderConfig
     name: provider-kubernetes
@@ -154,12 +179,12 @@ metadata:
   name: observe-john-s-joe
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-john
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-john
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -169,7 +194,7 @@ spec:
         name: john.s-joe
         namespace: default
   managementPolicies:
-  - Observe
+    - Observe
   providerConfigRef:
     kind: ProviderConfig
     name: provider-kubernetes
@@ -184,12 +209,12 @@ metadata:
   name: jane.s-john
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-john
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-john
+      uid: ""
 spec:
   forProvider:
     policy: |-
@@ -211,12 +236,12 @@ metadata:
   name: john.s-john
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-john
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-john
+      uid: ""
 spec:
   forProvider:
     policy: |-
@@ -249,12 +274,12 @@ metadata:
   name: john.s-john
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-john
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-john
+      uid: ""
 spec:
   forProvider:
     policyArnRef:
@@ -275,12 +300,12 @@ metadata:
   name: john
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-john
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-john
+      uid: ""
 spec:
   forProvider: {}
   providerConfigRef:

--- a/docs/how-to-guides/installation.md
+++ b/docs/how-to-guides/installation.md
@@ -9,9 +9,9 @@ Buckets, access policies, and cross-user sharing are declared via a single, name
 
 Everything in this guide is **namespaced**:
 
-- You **apply** `Storage` claims **to a namespace** (e.g., `workspace`).  
-- The **provisioned Secret lives in the same namespace** as the `Storage` claim (Secret name = **principal**).  
-- Any **namespaced ProviderConfigs** or supporting objects that the compositions depend on **must exist in that same target namespace** (e.g., `workspace`).  
+- You **apply** `Storage` claims **to a namespace** (e.g., `workspace`).
+- The **provisioned Secret lives in the same namespace** as the `Storage` claim (Secret name = **principal**).
+- Any **namespaced ProviderConfigs** or supporting objects that the compositions depend on **must exist in that same target namespace** (e.g., `workspace`).
 
 > In short: choose your target namespace (e.g., `workspace`), apply the provider configs there, and create your `Storage` claims in that namespace.
 
@@ -19,9 +19,9 @@ Everything in this guide is **namespaced**:
 
 ## Prerequisites
 
-- A running Kubernetes cluster (e.g., `kind`, managed K8s).  
-- `kubectl` access.  
-- **Crossplane** installed in the cluster:  
+- A running Kubernetes cluster (e.g., `kind`, managed K8s).
+- `kubectl` access.
+- **Crossplane** installed in the cluster:
 
 ```bash
 helm repo add crossplane-stable https://charts.crossplane.io/stable
@@ -29,7 +29,7 @@ helm repo update
 helm install crossplane
   --namespace crossplane-system
   --create-namespace crossplane-stable/crossplane
-  --version 2.0.2 
+  --version 2.0.2
   --set provider.defaultActivations={}
 ```
 
@@ -40,11 +40,12 @@ helm install crossplane
 ## Step 1 – Install Provider Dependencies (per backend)
 
 All providers follow the same staged pattern you **must** install **before** the configuration package:
-1. **ManagedResourceActivationPolicy** – activate only the resource kinds that are needed.  
-2. **Deployment Runtime Configs** – define how providers/functions run.  
-3. **Providers** – install the required Crossplane providers.  
-4. **ProviderConfigs** (namespaced) – point providers to endpoints/credentials in your target namespace.  
-5. **Functions** – install supporting Crossplane Functions.  
+
+1. **ManagedResourceActivationPolicy** – activate only the resource kinds that are needed.
+2. **Deployment Runtime Configs** – define how providers/functions run.
+3. **Providers** – install the required Crossplane providers.
+4. **ProviderConfigs** (namespaced) – point providers to endpoints/credentials in your target namespace.
+5. **Functions** – install supporting Crossplane Functions.
 6. **RBAC** – permissions for `provider-kubernetes` to observe and reconcile objects.
 
 Repository root: <https://github.com/versioneer-tech/provider-storage/>
@@ -53,33 +54,33 @@ Repository root: <https://github.com/versioneer-tech/provider-storage/>
 
 > You operate a MinIO endpoint yourself (same/different cluster or DC). For a one-stop local dev on `kind`, see the guide around [**Local Setup**](how-to-guides/local_setup.md).
 
-- [00-mrap.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/minio/dependencies/00-mrap.yaml) – Activate MinIO-specific Managed Resources.  
-- [01-deploymentRuntimeConfigs.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/minio/dependencies/01-deploymentRuntimeConfigs.yaml) – Runtime configs for providers/functions.  
-- [02-providers.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/minio/dependencies/02-providers.yaml) – Install `provider-minio` and `provider-kubernetes`.  
-- [03-providerConfigs.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/minio/dependencies/03-providerConfigs.yaml) – **Apply in your target namespace** (e.g., `workspace`); points to your MinIO endpoint/credentials.  
-- [functions.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/minio/dependencies/functions.yaml) – Functions used by compositions.  
+- [00-mrap.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/minio/dependencies/00-mrap.yaml) – Activate MinIO-specific Managed Resources.
+- [01-deploymentRuntimeConfigs.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/minio/dependencies/01-deploymentRuntimeConfigs.yaml) – Runtime configs for providers/functions.
+- [02-providers.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/minio/dependencies/02-providers.yaml) – Install `provider-minio` and `provider-kubernetes`.
+- [03-providerConfigs.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/minio/dependencies/03-providerConfigs.yaml) – **Apply in your target namespace** (e.g., `workspace`); points to your MinIO endpoint/credentials.
+- [functions.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/minio/dependencies/functions.yaml) – Functions used by compositions.
 - [rbac.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/minio/dependencies/rbac.yaml) – RBAC for `provider-kubernetes`.
 
 ### AWS
 
 > You provide endpoint configuration and credentials via a Secret referenced by a namespaced `ProviderConfig`.
 
-- [00-mrap.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/aws/dependencies/00-mrap.yaml) – Activate AWS S3/IAM Managed Resources.  
-- [01-deploymentRuntimeConfigs.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/aws/dependencies/01-deploymentRuntimeConfigs.yaml) – Runtime configs for AWS + Kubernetes providers.  
-- [02-providers.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/aws/dependencies/02-providers.yaml) – Install `provider-upjet-aws` and `provider-kubernetes`.  
+- [00-mrap.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/aws/dependencies/00-mrap.yaml) – Activate AWS S3/IAM Managed Resources.
+- [01-deploymentRuntimeConfigs.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/aws/dependencies/01-deploymentRuntimeConfigs.yaml) – Runtime configs for AWS + Kubernetes providers.
+- [02-providers.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/aws/dependencies/02-providers.yaml) – Install `provider-upjet-aws` and `provider-kubernetes`.
 - [03-providerConfigs.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/aws/dependencies/03-providerConfigs.yaml) – **Apply in your target namespace**; references AWS credentials Secret.
-- [functions.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/aws/dependencies/functions.yaml) – Functions used by compositions.  
+- [functions.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/aws/dependencies/functions.yaml) – Functions used by compositions.
 - [rbac.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/aws/dependencies/rbac.yaml) – RBAC for `provider-kubernetes`.
 
 ### OTC
 
 > You do **not** deploy OBS; you provide OTC credentials via a Secret referenced by a namespaced `ProviderConfig`.
 
-- [00-mrap.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/otc/dependencies/00-mrap.yaml) – Activate OTC Managed Resources.  
-- [01-deploymentRuntimeConfigs.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/otc/dependencies/01-deploymentRuntimeConfigs.yaml) – Runtime configs for OTC + Kubernetes providers.  
-- [02-providers.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/otc/dependencies/02-providers.yaml) – Install OTC provider(s) and `provider-kubernetes`.  
+- [00-mrap.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/otc/dependencies/00-mrap.yaml) – Activate OTC Managed Resources.
+- [01-deploymentRuntimeConfigs.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/otc/dependencies/01-deploymentRuntimeConfigs.yaml) – Runtime configs for OTC + Kubernetes providers.
+- [02-providers.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/otc/dependencies/02-providers.yaml) – Install OTC provider(s) and `provider-kubernetes`.
 - [03-providerConfigs.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/otc/dependencies/03-providerConfigs.yaml) – **Apply in your target namespace**; references OTC credentials Secret.
-- [functions.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/otc/dependencies/functions.yaml) – Functions used by compositions.  
+- [functions.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/otc/dependencies/functions.yaml) – Functions used by compositions.
 - [rbac.yaml](https://github.com/versioneer-tech/provider-storage/blob/main/otc/dependencies/rbac.yaml) – RBAC for `provider-kubernetes`.
 
 ---
@@ -132,3 +133,7 @@ kubectl apply -f configuration.yaml
 ## Step 3 – (Optional) Quick Verification
 
 After the package installs and providers are healthy, you can create a minimal `Storage` claim in your target namespace and verify readiness and credentials. See the **Usage & Concepts** guide for details (`kubectl get storages -n <ns>`, and inspect the Secret named after the principal).
+
+## Step 4 – (Optional) Credential Rotation
+
+Currently, the provider creates long-lived credentials as Kubernetes secrets in the cluster. In order to enable credential rotation you can use the templates in [examples/manifests/](https://github.com/versioneer-tech/provider-storage/tree/main/examples/manifests) to deploy a CronJob which deletes the oldest available credential at the specified `schedule`. The `interval` defines how long a credential should live before it is deleted.

--- a/examples/manifests/cred-rotation-aws.yaml
+++ b/examples/manifests/cred-rotation-aws.yaml
@@ -11,9 +11,9 @@ metadata:
   name: credential-rotator-cr
 rules:
   - apiGroups:
-      - "kubernetes.m.crossplane.io"
+      - "iam.aws.m.upbound.io"
     resources:
-      - objects
+      - accesskeys
     verbs:
       - get
       - list
@@ -66,14 +66,15 @@ spec:
 
                   interval=86400
                   now=$(date +%s)
-                  objects=$(kubectl get objects.kubernetes.m.crossplane.io --all-namespaces \
+                  objects=$(kubectl get accesskeys.iam.aws.m.upbound.io --all-namespaces \
                       -o jsonpath="{range .items[*]}{.metadata.namespace}{'\t'}{.metadata.name}{'\t'}{.metadata.annotations.crossplane\.io/composition-resource-name}{'\t'}{.metadata.creationTimestamp}{'\n'}{end}")
 
                   deleted_groups=""
 
                   while IFS=$'\t' read -r namespace name compositionResourceName creationTimestamp; do
-                      [[ "$compositionResourceName" == user-* ]] || continue
+                      [[ "$compositionResourceName" == access-key-* ]] || continue
 
+                      # Skip if group already deleted
                       group="${name%-*}"
                       if echo " $deleted_groups " | grep -q " $group "; then
                           continue
@@ -81,9 +82,10 @@ spec:
 
                       creationTimestampSeconds=$(date -d "${creationTimestamp}" +%s)
                       validUntil=$((creationTimestampSeconds + interval))
+
                       if (( validUntil < now )); then
                           echo "Deleting $namespace/$name (creationTimestamp: ${creationTimestampSeconds}, now: ${now})"
-                          kubectl delete objects.kubernetes.m.crossplane.io "$name" -n "$namespace"
+                          kubectl delete accesskeys.iam.aws.m.upbound.io "$name" -n "$namespace"
 
                           deleted_groups="${deleted_groups} ${group}"
                       fi

--- a/examples/manifests/cred-rotation-minio.yaml
+++ b/examples/manifests/cred-rotation-minio.yaml
@@ -1,0 +1,94 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: credential-rotator-sa
+  namespace: crossplane
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: credential-rotator-cr
+rules:
+  - apiGroups:
+      - "kubernetes.m.crossplane.io"
+    resources:
+      - objects
+    verbs:
+      - get
+      - list
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: credential-rotator-crb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: credential-rotator-cr
+subjects:
+  - kind: ServiceAccount
+    name: credential-rotator-sa
+    namespace: crossplane
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: credential-rotator-minio
+  namespace: crossplane
+spec:
+  schedule: "0 * * * *"
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 5
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: credential-rotator-sa
+          restartPolicy: OnFailure
+          containers:
+            - name: credential-rotator
+              image: bitnami/kubectl
+              command: ["/bin/bash", "-c"]
+              args:
+                - |
+                  set -euo pipefail
+
+                  interval=<REPLACE-ME-WITH-INTERVAL-IN-SECONDS>
+                  now=$(date +%s)
+                  objects=$(kubectl get objects.kubernetes.m.crossplane.io --all-namespaces \
+                      -o jsonpath="{range .items[*]}{.metadata.namespace}{'\t'}{.metadata.name}{'\t'}{.metadata.creationTimestamp}{'\n'}{end}")
+
+                  deleted_groups=""
+
+                  while IFS=$'\t' read -r namespace name creationTimestamp; do
+                      # Skip non-user objects or objects without a delete-by timestamp
+                      [[ "$name" == user-* ]] || continue
+
+                      # Skip if group already deleted
+                      group="${name%-*}"
+                      if echo " $deleted_groups " | grep -q " $group "; then
+                          continue
+                      fi
+
+                      # Only delete if delete-by timestamp has passed
+                      creationTimestampSeconds=$(date -d "${creationTimestamp}" +%s)
+                      validUntil=$((creationTimestampSeconds + interval))
+
+                      if (( validUntil < now )); then
+                          echo "Deleting $namespace/$name (creationTimestamp: ${creationTimestampSeconds}, now: ${now})"
+                          kubectl delete objects.kubernetes.m.crossplane.io "$name" -n "$namespace"
+
+                          deleted_groups="${deleted_groups} ${group}"
+                      fi
+                  done <<< "$objects"

--- a/minio/composition.yaml
+++ b/minio/composition.yaml
@@ -305,10 +305,6 @@ spec:
                   "key": f"user-{principal}-2",
               }
 
-              current_time = time.time()
-              credentialRotationInterval = spec.get("credentialRotationInterval")
-              expiration_time = int(current_time + credentialRotationInterval) if credentialRotationInterval else -1
-
               for user in [user_1, user_2]:
                   key = user["key"]
                   user_name = user["name"]

--- a/minio/composition.yaml
+++ b/minio/composition.yaml
@@ -249,13 +249,15 @@ spec:
                       }
                   })
 
-    - step: create-user-with-policies
+    - step: create-users-with-policies
       functionRef:
         name: crossplane-contrib-function-python
       input:
         apiVersion: python.fn.crossplane.io/v1beta1
         kind: Script
         script: |
+          import time
+
           from crossplane.function.proto.v1 import run_function_pb2 as fnv1
           from google.protobuf import json_format
 
@@ -293,32 +295,52 @@ spec:
                   if exists:
                       policies.append(f"{principal}.{bucket}")
 
-              key = f"user-{principal}"
-              rsp.desired.resources[key].resource.update({
-                  "apiVersion": "kubernetes.m.crossplane.io/v1alpha1",
-                  "kind": "Object",
-                  "metadata": {
-                      "name": key,
-                      "namespace": ns,
-                      "annotations": {"crossplane.io/composition-resource-name": key}
-                  },
-                  "spec": {
-                      "forProvider": {
-                          "manifest": {
-                              "apiVersion": "minio.crossplane.io/v1",
-                              "kind": "User",
-                              "metadata": {"name": principal},
-                              "spec": {
-                                  "forProvider": {"userName": principal, "policies": policies},
-                                  "providerConfigRef": {"name": "provider-minio"},
-                                  "writeConnectionSecretToRef": {"name": principal, "namespace": ns}
-                              }
+              user_1 = {
+                  "name": f"{principal}-1",
+                  "key": f"user-{principal}-1",
+              }
+
+              user_2 = {
+                  "name": f"{principal}-2",
+                  "key": f"user-{principal}-2",
+              }
+
+              current_time = time.time()
+              credentialRotationInterval = spec.get("credentialRotationInterval")
+              expiration_time = int(current_time + credentialRotationInterval) if credentialRotationInterval else -1
+
+              for user in [user_1, user_2]:
+                  key = user["key"]
+                  user_name = user["name"]
+
+                  rsp.desired.resources[key].resource.update({
+                      "apiVersion": "kubernetes.m.crossplane.io/v1alpha1",
+                      "kind": "Object",
+                      "metadata": {
+                          "name": key,
+                          "namespace": ns,
+                          "annotations": {
+                              "crossplane.io/composition-resource-name": key,
                           }
                       },
-                      "providerConfigRef": {"name": "provider-kubernetes", "kind": "ProviderConfig"}
-                  }
-              })
-
+                      "spec": {
+                          "forProvider": {
+                              "manifest": {
+                                  "apiVersion": "minio.crossplane.io/v1",
+                                  "kind": "User",
+                                  "metadata": {
+                                      "name": user_name,
+                                  },
+                                  "spec": {
+                                      "forProvider": {"userName": user_name, "policies": policies},
+                                      "providerConfigRef": {"name": "provider-minio"},
+                                      "writeConnectionSecretToRef": {"name": user_name, "namespace": ns}
+                                  }
+                              }
+                          },
+                          "providerConfigRef": {"name": "provider-kubernetes", "kind": "ProviderConfig"}
+                      }
+                  })
     - step: automatically-detect-ready-composed-resources
       functionRef:
         name: crossplane-contrib-function-auto-ready

--- a/minio/tests/001-buckets.yaml
+++ b/minio/tests/001-buckets.yaml
@@ -1,6 +1,3 @@
-# Copyright 2025, EOX (https://eox.at) and Versioneer (https://versioneer.at)
-# SPDX-License-Identifier: Apache-2.0
-
 ---
 apiVersion: pkg.internal/v1beta1
 kind: Storage
@@ -24,7 +21,7 @@ status:
   conditions:
   - lastTransitionTime: "2024-01-01T00:00:00Z"
     message: 'Unready resources: bucket-s-joe, observe-joe-s-jeff-shared, policy-full-s-joe,
-      and 2 more'
+      and 3 more'
     reason: Creating
     status: "False"
     type: Ready
@@ -192,10 +189,10 @@ apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: Object
 metadata:
   annotations:
-    crossplane.io/composition-resource-name: user-joe
+    crossplane.io/composition-resource-name: user-joe-1
   labels:
     crossplane.io/composite: s-joe
-  name: user-joe
+  name: user-joe-1
   namespace: default
   ownerReferences:
   - apiVersion: pkg.internal/v1beta1
@@ -210,16 +207,53 @@ spec:
       apiVersion: minio.crossplane.io/v1
       kind: User
       metadata:
-        name: joe
+        name: joe-1
       spec:
         forProvider:
           policies:
           - joe.s-joe
-          userName: joe
+          userName: joe-1
         providerConfigRef:
           name: provider-minio
         writeConnectionSecretToRef:
-          name: joe
+          name: joe-1
+          namespace: default
+  providerConfigRef:
+    kind: ProviderConfig
+    name: provider-kubernetes
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: user-joe-2
+  labels:
+    crossplane.io/composite: s-joe
+  name: user-joe-2
+  namespace: default
+  ownerReferences:
+  - apiVersion: pkg.internal/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Storage
+    name: s-joe
+    uid: ""
+spec:
+  forProvider:
+    manifest:
+      apiVersion: minio.crossplane.io/v1
+      kind: User
+      metadata:
+        name: joe-2
+      spec:
+        forProvider:
+          policies:
+          - joe.s-joe
+          userName: joe-2
+        providerConfigRef:
+          name: provider-minio
+        writeConnectionSecretToRef:
+          name: joe-2
           namespace: default
   providerConfigRef:
     kind: ProviderConfig

--- a/minio/tests/001x-buckets.yaml
+++ b/minio/tests/001x-buckets.yaml
@@ -1,6 +1,3 @@
-# Copyright 2025, EOX (https://eox.at) and Versioneer (https://versioneer.at)
-# SPDX-License-Identifier: Apache-2.0
-
 ---
 apiVersion: pkg.internal/v1beta1
 kind: Storage
@@ -24,7 +21,7 @@ status:
   conditions:
   - lastTransitionTime: "2024-01-01T00:00:00Z"
     message: 'Unready resources: bucket-s-joe, observe-joe-s-jeff-shared, policy-full-s-joe,
-      and 2 more'
+      and 3 more'
     reason: Creating
     status: "False"
     type: Ready
@@ -192,10 +189,10 @@ apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: Object
 metadata:
   annotations:
-    crossplane.io/composition-resource-name: user-joe
+    crossplane.io/composition-resource-name: user-joe-1
   labels:
     crossplane.io/composite: s-joe
-  name: user-joe
+  name: user-joe-1
   namespace: default
   ownerReferences:
   - apiVersion: pkg.internal/v1beta1
@@ -210,16 +207,53 @@ spec:
       apiVersion: minio.crossplane.io/v1
       kind: User
       metadata:
-        name: joe
+        name: joe-1
       spec:
         forProvider:
           policies:
           - joe.s-joe
-          userName: joe
+          userName: joe-1
         providerConfigRef:
           name: provider-minio
         writeConnectionSecretToRef:
-          name: joe
+          name: joe-1
+          namespace: default
+  providerConfigRef:
+    kind: ProviderConfig
+    name: provider-kubernetes
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: user-joe-2
+  labels:
+    crossplane.io/composite: s-joe
+  name: user-joe-2
+  namespace: default
+  ownerReferences:
+  - apiVersion: pkg.internal/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Storage
+    name: s-joe
+    uid: ""
+spec:
+  forProvider:
+    manifest:
+      apiVersion: minio.crossplane.io/v1
+      kind: User
+      metadata:
+        name: joe-2
+      spec:
+        forProvider:
+          policies:
+          - joe.s-joe
+          userName: joe-2
+        providerConfigRef:
+          name: provider-minio
+        writeConnectionSecretToRef:
+          name: joe-2
           namespace: default
   providerConfigRef:
     kind: ProviderConfig

--- a/minio/tests/002-buckets.yaml
+++ b/minio/tests/002-buckets.yaml
@@ -1,6 +1,3 @@
-# Copyright 2025, EOX (https://eox.at) and Versioneer (https://versioneer.at)
-# SPDX-License-Identifier: Apache-2.0
-
 ---
 apiVersion: pkg.internal/v1beta1
 kind: Storage
@@ -25,7 +22,7 @@ status:
   conditions:
   - lastTransitionTime: "2024-01-01T00:00:00Z"
     message: 'Unready resources: bucket-s-jeff, bucket-s-jeff-shared, observe-jeff-s-joe,
-      and 4 more'
+      and 5 more'
     reason: Creating
     status: "False"
     type: Ready
@@ -277,10 +274,10 @@ apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: Object
 metadata:
   annotations:
-    crossplane.io/composition-resource-name: user-jeff
+    crossplane.io/composition-resource-name: user-jeff-1
   labels:
     crossplane.io/composite: s-jeff
-  name: user-jeff
+  name: user-jeff-1
   namespace: default
   ownerReferences:
   - apiVersion: pkg.internal/v1beta1
@@ -295,17 +292,55 @@ spec:
       apiVersion: minio.crossplane.io/v1
       kind: User
       metadata:
-        name: jeff
+        name: jeff-1
       spec:
         forProvider:
           policies:
           - jeff.s-jeff
           - jeff.s-jeff-shared
-          userName: jeff
+          userName: jeff-1
         providerConfigRef:
           name: provider-minio
         writeConnectionSecretToRef:
-          name: jeff
+          name: jeff-1
+          namespace: default
+  providerConfigRef:
+    kind: ProviderConfig
+    name: provider-kubernetes
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: user-jeff-2
+  labels:
+    crossplane.io/composite: s-jeff
+  name: user-jeff-2
+  namespace: default
+  ownerReferences:
+  - apiVersion: pkg.internal/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Storage
+    name: s-jeff
+    uid: ""
+spec:
+  forProvider:
+    manifest:
+      apiVersion: minio.crossplane.io/v1
+      kind: User
+      metadata:
+        name: jeff-2
+      spec:
+        forProvider:
+          policies:
+          - jeff.s-jeff
+          - jeff.s-jeff-shared
+          userName: jeff-2
+        providerConfigRef:
+          name: provider-minio
+        writeConnectionSecretToRef:
+          name: jeff-2
           namespace: default
   providerConfigRef:
     kind: ProviderConfig

--- a/minio/tests/003-buckets.yaml
+++ b/minio/tests/003-buckets.yaml
@@ -1,6 +1,3 @@
-# Copyright 2025, EOX (https://eox.at) and Versioneer (https://versioneer.at)
-# SPDX-License-Identifier: Apache-2.0
-
 ---
 apiVersion: pkg.internal/v1beta1
 kind: Storage
@@ -16,7 +13,7 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2024-01-01T00:00:00Z"
-    message: 'Unready resources: observe-jane-s-john, user-jane'
+    message: 'Unready resources: observe-jane-s-john, user-jane-1, and user-jane-2'
     reason: Creating
     status: "False"
     type: Ready
@@ -54,10 +51,10 @@ apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: Object
 metadata:
   annotations:
-    crossplane.io/composition-resource-name: user-jane
+    crossplane.io/composition-resource-name: user-jane-1
   labels:
     crossplane.io/composite: s-jane
-  name: user-jane
+  name: user-jane-1
   namespace: default
   ownerReferences:
   - apiVersion: pkg.internal/v1beta1
@@ -72,15 +69,51 @@ spec:
       apiVersion: minio.crossplane.io/v1
       kind: User
       metadata:
-        name: jane
+        name: jane-1
       spec:
         forProvider:
           policies: []
-          userName: jane
+          userName: jane-1
         providerConfigRef:
           name: provider-minio
         writeConnectionSecretToRef:
-          name: jane
+          name: jane-1
+          namespace: default
+  providerConfigRef:
+    kind: ProviderConfig
+    name: provider-kubernetes
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: user-jane-2
+  labels:
+    crossplane.io/composite: s-jane
+  name: user-jane-2
+  namespace: default
+  ownerReferences:
+  - apiVersion: pkg.internal/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Storage
+    name: s-jane
+    uid: ""
+spec:
+  forProvider:
+    manifest:
+      apiVersion: minio.crossplane.io/v1
+      kind: User
+      metadata:
+        name: jane-2
+      spec:
+        forProvider:
+          policies: []
+          userName: jane-2
+        providerConfigRef:
+          name: provider-minio
+        writeConnectionSecretToRef:
+          name: jane-2
           namespace: default
   providerConfigRef:
     kind: ProviderConfig

--- a/minio/tests/004-buckets.yaml
+++ b/minio/tests/004-buckets.yaml
@@ -1,6 +1,3 @@
-# Copyright 2025, EOX (https://eox.at) and Versioneer (https://versioneer.at)
-# SPDX-License-Identifier: Apache-2.0
-
 ---
 apiVersion: pkg.internal/v1beta1
 kind: Storage
@@ -30,7 +27,7 @@ status:
   conditions:
   - lastTransitionTime: "2024-01-01T00:00:00Z"
     message: 'Unready resources: bucket-s-john, observe-john-s-jane, observe-john-s-jeff,
-      and 4 more'
+      and 5 more'
     reason: Creating
     status: "False"
     type: Ready
@@ -241,10 +238,10 @@ apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: Object
 metadata:
   annotations:
-    crossplane.io/composition-resource-name: user-john
+    crossplane.io/composition-resource-name: user-john-1
   labels:
     crossplane.io/composite: s-john
-  name: user-john
+  name: user-john-1
   namespace: default
   ownerReferences:
   - apiVersion: pkg.internal/v1beta1
@@ -259,16 +256,53 @@ spec:
       apiVersion: minio.crossplane.io/v1
       kind: User
       metadata:
-        name: john
+        name: john-1
       spec:
         forProvider:
           policies:
           - john.s-john
-          userName: john
+          userName: john-1
         providerConfigRef:
           name: provider-minio
         writeConnectionSecretToRef:
-          name: john
+          name: john-1
+          namespace: default
+  providerConfigRef:
+    kind: ProviderConfig
+    name: provider-kubernetes
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: user-john-2
+  labels:
+    crossplane.io/composite: s-john
+  name: user-john-2
+  namespace: default
+  ownerReferences:
+  - apiVersion: pkg.internal/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Storage
+    name: s-john
+    uid: ""
+spec:
+  forProvider:
+    manifest:
+      apiVersion: minio.crossplane.io/v1
+      kind: User
+      metadata:
+        name: john-2
+      spec:
+        forProvider:
+          policies:
+          - john.s-john
+          userName: john-2
+        providerConfigRef:
+          name: provider-minio
+        writeConnectionSecretToRef:
+          name: john-2
           namespace: default
   providerConfigRef:
     kind: ProviderConfig

--- a/minio/tests/expected/001-buckets.yaml
+++ b/minio/tests/expected/001-buckets.yaml
@@ -8,26 +8,27 @@ metadata:
   name: s-joe
 spec:
   bucketAccessGrants:
-  - bucketName: s-joe
-    grantedAt: "2025-09-29T10:05:00Z"
-    grantee: jeff
-    permission: ReadWrite
+    - bucketName: s-joe
+      grantedAt: "2025-09-29T10:05:00Z"
+      grantee: jeff
+      permission: ReadWrite
   bucketAccessRequests:
-  - bucketName: s-jeff-shared
-    reason: Need access
-    requestedAt: "2025-09-29T10:00:00Z"
+    - bucketName: s-jeff-shared
+      reason: Need access
+      requestedAt: "2025-09-29T10:00:00Z"
   buckets:
-  - bucketName: s-joe
-    discoverable: true
+    - bucketName: s-joe
+      discoverable: true
   principal: joe
 status:
   conditions:
-  - lastTransitionTime: "2024-01-01T00:00:00Z"
-    message: 'Unready resources: bucket-s-joe, observe-joe-s-jeff-shared, policy-full-s-joe,
-      and 2 more'
-    reason: Creating
-    status: "False"
-    type: Ready
+    - lastTransitionTime: "2024-01-01T00:00:00Z"
+      message:
+        "Unready resources: bucket-s-joe, observe-joe-s-jeff-shared, policy-full-s-joe,
+        and 3 more"
+      reason: Creating
+      status: "False"
+      type: Ready
 ---
 apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: Object
@@ -39,12 +40,12 @@ metadata:
   name: bucket-s-joe
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -71,12 +72,12 @@ metadata:
   name: observe-joe-s-jeff-shared
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -85,7 +86,7 @@ spec:
       metadata:
         name: joe.s-jeff-shared
   managementPolicies:
-  - Observe
+    - Observe
   providerConfigRef:
     kind: ProviderConfig
     name: provider-kubernetes
@@ -100,12 +101,12 @@ metadata:
   name: policy-full-s-joe
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -147,12 +148,12 @@ metadata:
   name: policy-jeff-s-joe
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -192,34 +193,71 @@ apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: Object
 metadata:
   annotations:
-    crossplane.io/composition-resource-name: user-joe
+    crossplane.io/composition-resource-name: user-joe-1
   labels:
     crossplane.io/composite: s-joe
-  name: user-joe
+  name: user-joe-1
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     manifest:
       apiVersion: minio.crossplane.io/v1
       kind: User
       metadata:
-        name: joe
+        name: joe-1
       spec:
         forProvider:
           policies:
-          - joe.s-joe
-          userName: joe
+            - joe.s-joe
+          userName: joe-1
         providerConfigRef:
           name: provider-minio
         writeConnectionSecretToRef:
-          name: joe
+          name: joe-1
+          namespace: default
+  providerConfigRef:
+    kind: ProviderConfig
+    name: provider-kubernetes
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: user-joe-2
+  labels:
+    crossplane.io/composite: s-joe
+  name: user-joe-2
+  namespace: default
+  ownerReferences:
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
+spec:
+  forProvider:
+    manifest:
+      apiVersion: minio.crossplane.io/v1
+      kind: User
+      metadata:
+        name: joe-2
+      spec:
+        forProvider:
+          policies:
+            - joe.s-joe
+          userName: joe-2
+        providerConfigRef:
+          name: provider-minio
+        writeConnectionSecretToRef:
+          name: joe-2
           namespace: default
   providerConfigRef:
     kind: ProviderConfig

--- a/minio/tests/expected/001x-buckets.yaml
+++ b/minio/tests/expected/001x-buckets.yaml
@@ -8,26 +8,27 @@ metadata:
   name: s-joe
 spec:
   bucketAccessGrants:
-  - bucketName: s-joe
-    grantedAt: "2025-09-29T10:05:00Z"
-    grantee: jeff
-    permission: ReadWrite
+    - bucketName: s-joe
+      grantedAt: "2025-09-29T10:05:00Z"
+      grantee: jeff
+      permission: ReadWrite
   bucketAccessRequests:
-  - bucketName: s-jeff-shared
-    reason: Need access
-    requestedAt: "2025-09-29T10:00:00Z"
+    - bucketName: s-jeff-shared
+      reason: Need access
+      requestedAt: "2025-09-29T10:00:00Z"
   buckets:
-  - bucketName: s-joe
-    discoverable: true
+    - bucketName: s-joe
+      discoverable: true
   principal: joe
 status:
   conditions:
-  - lastTransitionTime: "2024-01-01T00:00:00Z"
-    message: 'Unready resources: bucket-s-joe, observe-joe-s-jeff-shared, policy-full-s-joe,
-      and 2 more'
-    reason: Creating
-    status: "False"
-    type: Ready
+    - lastTransitionTime: "2024-01-01T00:00:00Z"
+      message:
+        "Unready resources: bucket-s-joe, observe-joe-s-jeff-shared, policy-full-s-joe,
+        and 3 more"
+      reason: Creating
+      status: "False"
+      type: Ready
 ---
 apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: Object
@@ -39,12 +40,12 @@ metadata:
   name: bucket-s-joe
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -71,12 +72,12 @@ metadata:
   name: observe-joe-s-jeff-shared
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -85,7 +86,7 @@ spec:
       metadata:
         name: joe.s-jeff-shared
   managementPolicies:
-  - Observe
+    - Observe
   providerConfigRef:
     kind: ProviderConfig
     name: provider-kubernetes
@@ -100,12 +101,12 @@ metadata:
   name: policy-full-s-joe
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -147,12 +148,12 @@ metadata:
   name: policy-jeff-s-joe
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -192,34 +193,71 @@ apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: Object
 metadata:
   annotations:
-    crossplane.io/composition-resource-name: user-joe
+    crossplane.io/composition-resource-name: user-joe-1
   labels:
     crossplane.io/composite: s-joe
-  name: user-joe
+  name: user-joe-1
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-joe
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
 spec:
   forProvider:
     manifest:
       apiVersion: minio.crossplane.io/v1
       kind: User
       metadata:
-        name: joe
+        name: joe-1
       spec:
         forProvider:
           policies:
-          - joe.s-joe
-          userName: joe
+            - joe.s-joe
+          userName: joe-1
         providerConfigRef:
           name: provider-minio
         writeConnectionSecretToRef:
-          name: joe
+          name: joe-1
+          namespace: default
+  providerConfigRef:
+    kind: ProviderConfig
+    name: provider-kubernetes
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: user-joe-2
+  labels:
+    crossplane.io/composite: s-joe
+  name: user-joe-2
+  namespace: default
+  ownerReferences:
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-joe
+      uid: ""
+spec:
+  forProvider:
+    manifest:
+      apiVersion: minio.crossplane.io/v1
+      kind: User
+      metadata:
+        name: joe-2
+      spec:
+        forProvider:
+          policies:
+            - joe.s-joe
+          userName: joe-2
+        providerConfigRef:
+          name: provider-minio
+        writeConnectionSecretToRef:
+          name: joe-2
           namespace: default
   providerConfigRef:
     kind: ProviderConfig

--- a/minio/tests/expected/002-buckets.yaml
+++ b/minio/tests/expected/002-buckets.yaml
@@ -8,27 +8,28 @@ metadata:
   name: s-jeff
 spec:
   bucketAccessGrants:
-  - bucketName: s-jeff-shared
-    grantedAt: "2025-09-29T10:15:00Z"
-    grantee: joe
-    permission: ReadOnly
+    - bucketName: s-jeff-shared
+      grantedAt: "2025-09-29T10:15:00Z"
+      grantee: joe
+      permission: ReadOnly
   bucketAccessRequests:
-  - bucketName: s-joe
-    reason: Need access
-    requestedAt: "2025-09-29T10:10:00Z"
+    - bucketName: s-joe
+      reason: Need access
+      requestedAt: "2025-09-29T10:10:00Z"
   buckets:
-  - bucketName: s-jeff
-  - bucketName: s-jeff-shared
-    discoverable: true
+    - bucketName: s-jeff
+    - bucketName: s-jeff-shared
+      discoverable: true
   principal: jeff
 status:
   conditions:
-  - lastTransitionTime: "2024-01-01T00:00:00Z"
-    message: 'Unready resources: bucket-s-jeff, bucket-s-jeff-shared, observe-jeff-s-joe,
-      and 4 more'
-    reason: Creating
-    status: "False"
-    type: Ready
+    - lastTransitionTime: "2024-01-01T00:00:00Z"
+      message:
+        "Unready resources: bucket-s-jeff, bucket-s-jeff-shared, observe-jeff-s-joe,
+        and 5 more"
+      reason: Creating
+      status: "False"
+      type: Ready
 ---
 apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: Object
@@ -40,12 +41,12 @@ metadata:
   name: bucket-s-jeff
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jeff
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jeff
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -72,12 +73,12 @@ metadata:
   name: bucket-s-jeff-shared
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jeff
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jeff
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -104,12 +105,12 @@ metadata:
   name: observe-jeff-s-joe
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jeff
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jeff
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -118,7 +119,7 @@ spec:
       metadata:
         name: jeff.s-joe
   managementPolicies:
-  - Observe
+    - Observe
   providerConfigRef:
     kind: ProviderConfig
     name: provider-kubernetes
@@ -133,12 +134,12 @@ metadata:
   name: policy-full-s-jeff
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jeff
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jeff
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -180,12 +181,12 @@ metadata:
   name: policy-full-s-jeff-shared
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jeff
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jeff
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -227,12 +228,12 @@ metadata:
   name: policy-joe-s-jeff-shared
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jeff
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jeff
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -277,35 +278,73 @@ apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: Object
 metadata:
   annotations:
-    crossplane.io/composition-resource-name: user-jeff
+    crossplane.io/composition-resource-name: user-jeff-1
   labels:
     crossplane.io/composite: s-jeff
-  name: user-jeff
+  name: user-jeff-1
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jeff
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jeff
+      uid: ""
 spec:
   forProvider:
     manifest:
       apiVersion: minio.crossplane.io/v1
       kind: User
       metadata:
-        name: jeff
+        name: jeff-1
       spec:
         forProvider:
           policies:
-          - jeff.s-jeff
-          - jeff.s-jeff-shared
-          userName: jeff
+            - jeff.s-jeff
+            - jeff.s-jeff-shared
+          userName: jeff-1
         providerConfigRef:
           name: provider-minio
         writeConnectionSecretToRef:
-          name: jeff
+          name: jeff-1
+          namespace: default
+  providerConfigRef:
+    kind: ProviderConfig
+    name: provider-kubernetes
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: user-jeff-2
+  labels:
+    crossplane.io/composite: s-jeff
+  name: user-jeff-2
+  namespace: default
+  ownerReferences:
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jeff
+      uid: ""
+spec:
+  forProvider:
+    manifest:
+      apiVersion: minio.crossplane.io/v1
+      kind: User
+      metadata:
+        name: jeff-2
+      spec:
+        forProvider:
+          policies:
+            - jeff.s-jeff
+            - jeff.s-jeff-shared
+          userName: jeff-2
+        providerConfigRef:
+          name: provider-minio
+        writeConnectionSecretToRef:
+          name: jeff-2
           namespace: default
   providerConfigRef:
     kind: ProviderConfig

--- a/minio/tests/expected/003-buckets.yaml
+++ b/minio/tests/expected/003-buckets.yaml
@@ -8,18 +8,18 @@ metadata:
   name: s-jane
 spec:
   bucketAccessRequests:
-  - bucketName: s-john
-    reason: Need WriteOnly access
-    requestedAt: "2025-09-29T10:20:00Z"
+    - bucketName: s-john
+      reason: Need WriteOnly access
+      requestedAt: "2025-09-29T10:20:00Z"
   buckets: []
   principal: jane
 status:
   conditions:
-  - lastTransitionTime: "2024-01-01T00:00:00Z"
-    message: 'Unready resources: observe-jane-s-john, user-jane'
-    reason: Creating
-    status: "False"
-    type: Ready
+    - lastTransitionTime: "2024-01-01T00:00:00Z"
+      message: "Unready resources: observe-jane-s-john, user-jane-1, and user-jane-2"
+      reason: Creating
+      status: "False"
+      type: Ready
 ---
 apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: Object
@@ -31,12 +31,12 @@ metadata:
   name: observe-jane-s-john
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jane
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jane
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -45,7 +45,7 @@ spec:
       metadata:
         name: jane.s-john
   managementPolicies:
-  - Observe
+    - Observe
   providerConfigRef:
     kind: ProviderConfig
     name: provider-kubernetes
@@ -54,33 +54,69 @@ apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: Object
 metadata:
   annotations:
-    crossplane.io/composition-resource-name: user-jane
+    crossplane.io/composition-resource-name: user-jane-1
   labels:
     crossplane.io/composite: s-jane
-  name: user-jane
+  name: user-jane-1
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-jane
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jane
+      uid: ""
 spec:
   forProvider:
     manifest:
       apiVersion: minio.crossplane.io/v1
       kind: User
       metadata:
-        name: jane
+        name: jane-1
       spec:
         forProvider:
           policies: []
-          userName: jane
+          userName: jane-1
         providerConfigRef:
           name: provider-minio
         writeConnectionSecretToRef:
-          name: jane
+          name: jane-1
+          namespace: default
+  providerConfigRef:
+    kind: ProviderConfig
+    name: provider-kubernetes
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: user-jane-2
+  labels:
+    crossplane.io/composite: s-jane
+  name: user-jane-2
+  namespace: default
+  ownerReferences:
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-jane
+      uid: ""
+spec:
+  forProvider:
+    manifest:
+      apiVersion: minio.crossplane.io/v1
+      kind: User
+      metadata:
+        name: jane-2
+      spec:
+        forProvider:
+          policies: []
+          userName: jane-2
+        providerConfigRef:
+          name: provider-minio
+        writeConnectionSecretToRef:
+          name: jane-2
           namespace: default
   providerConfigRef:
     kind: ProviderConfig

--- a/minio/tests/expected/004-buckets.yaml
+++ b/minio/tests/expected/004-buckets.yaml
@@ -8,32 +8,33 @@ metadata:
   name: s-john
 spec:
   bucketAccessGrants:
-  - bucketName: s-john
-    grantedAt: "2025-09-29T10:28:00Z"
-    grantee: jane
-    permission: None
+    - bucketName: s-john
+      grantedAt: "2025-09-29T10:28:00Z"
+      grantee: jane
+      permission: None
   bucketAccessRequests:
-  - bucketName: s-joe
-    reason: Need access
-    requestedAt: "2025-09-29T10:25:00Z"
-  - bucketName: s-jeff
-    reason: Need access
-    requestedAt: "2025-09-29T10:26:00Z"
-  - bucketName: s-jane
-    reason: Need access
-    requestedAt: "2025-09-29T10:27:00Z"
+    - bucketName: s-joe
+      reason: Need access
+      requestedAt: "2025-09-29T10:25:00Z"
+    - bucketName: s-jeff
+      reason: Need access
+      requestedAt: "2025-09-29T10:26:00Z"
+    - bucketName: s-jane
+      reason: Need access
+      requestedAt: "2025-09-29T10:27:00Z"
   buckets:
-  - bucketName: s-john
-    discoverable: true
+    - bucketName: s-john
+      discoverable: true
   principal: john
 status:
   conditions:
-  - lastTransitionTime: "2024-01-01T00:00:00Z"
-    message: 'Unready resources: bucket-s-john, observe-john-s-jane, observe-john-s-jeff,
-      and 4 more'
-    reason: Creating
-    status: "False"
-    type: Ready
+    - lastTransitionTime: "2024-01-01T00:00:00Z"
+      message:
+        "Unready resources: bucket-s-john, observe-john-s-jane, observe-john-s-jeff,
+        and 5 more"
+      reason: Creating
+      status: "False"
+      type: Ready
 ---
 apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: Object
@@ -45,12 +46,12 @@ metadata:
   name: bucket-s-john
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-john
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-john
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -77,12 +78,12 @@ metadata:
   name: observe-john-s-jane
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-john
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-john
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -91,7 +92,7 @@ spec:
       metadata:
         name: john.s-jane
   managementPolicies:
-  - Observe
+    - Observe
   providerConfigRef:
     kind: ProviderConfig
     name: provider-kubernetes
@@ -106,12 +107,12 @@ metadata:
   name: observe-john-s-jeff
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-john
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-john
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -120,7 +121,7 @@ spec:
       metadata:
         name: john.s-jeff
   managementPolicies:
-  - Observe
+    - Observe
   providerConfigRef:
     kind: ProviderConfig
     name: provider-kubernetes
@@ -135,12 +136,12 @@ metadata:
   name: observe-john-s-joe
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-john
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-john
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -149,7 +150,7 @@ spec:
       metadata:
         name: john.s-joe
   managementPolicies:
-  - Observe
+    - Observe
   providerConfigRef:
     kind: ProviderConfig
     name: provider-kubernetes
@@ -164,12 +165,12 @@ metadata:
   name: policy-full-s-john
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-john
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-john
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -211,12 +212,12 @@ metadata:
   name: policy-jane-s-john
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-john
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-john
+      uid: ""
 spec:
   forProvider:
     manifest:
@@ -241,34 +242,71 @@ apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: Object
 metadata:
   annotations:
-    crossplane.io/composition-resource-name: user-john
+    crossplane.io/composition-resource-name: user-john-1
   labels:
     crossplane.io/composite: s-john
-  name: user-john
+  name: user-john-1
   namespace: default
   ownerReferences:
-  - apiVersion: pkg.internal/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Storage
-    name: s-john
-    uid: ""
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-john
+      uid: ""
 spec:
   forProvider:
     manifest:
       apiVersion: minio.crossplane.io/v1
       kind: User
       metadata:
-        name: john
+        name: john-1
       spec:
         forProvider:
           policies:
-          - john.s-john
-          userName: john
+            - john.s-john
+          userName: john-1
         providerConfigRef:
           name: provider-minio
         writeConnectionSecretToRef:
-          name: john
+          name: john-1
+          namespace: default
+  providerConfigRef:
+    kind: ProviderConfig
+    name: provider-kubernetes
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: user-john-2
+  labels:
+    crossplane.io/composite: s-john
+  name: user-john-2
+  namespace: default
+  ownerReferences:
+    - apiVersion: pkg.internal/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Storage
+      name: s-john
+      uid: ""
+spec:
+  forProvider:
+    manifest:
+      apiVersion: minio.crossplane.io/v1
+      kind: User
+      metadata:
+        name: john-2
+      spec:
+        forProvider:
+          policies:
+            - john.s-john
+          userName: john-2
+        providerConfigRef:
+          name: provider-minio
+        writeConnectionSecretToRef:
+          name: john-2
           namespace: default
   providerConfigRef:
     kind: ProviderConfig


### PR DESCRIPTION
The composition creates two User objects now in order to have multiple "keys" with the same permissions. They can be rotated (deleted) with a CronJob. An example is given in in
examples/manifests/cred-rotation.minio.yaml. Under "interval" the validity period of the keys can be set in seconds, e.g. 86400 for one day.