### PR TITLE
e2e

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,7 +26,7 @@ jobs:
       LIFECYCLE_WAIT_SECONDS: "75"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create kind cluster
         uses: helm/kind-action@v1

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The following S3 compatible storage systems are supported:
 
 ✨ For a full introduction, see the [documentation](https://versioneer-tech.github.io/provider-storage/).
 
+For local setup and MinIO end-to-end testing, see the [local setup guide](https://versioneer-tech.github.io/provider-storage/latest/how-to-guides/local_setup/).
+
 ## API Reference
 
 The published XRD with all fields is documented here:  

--- a/minio/tests/e2e.bash
+++ b/minio/tests/e2e.bash
@@ -114,12 +114,37 @@ apply_namespace() {
   kubectl create namespace "$1" --dry-run=client -o yaml | kubectl apply -f -
 }
 
+show_core_state() {
+  log "Kubernetes core state"
+  echo "+ kubectl get pods --all-namespaces"
+  kubectl get pods --all-namespaces || true
+  echo "+ kubectl get providers,functions"
+  kubectl get providers.pkg.crossplane.io,functions.pkg.crossplane.io || true
+  echo "+ kubectl get providerconfigs and EnvironmentConfig"
+  kubectl get providerconfigs.minio.crossplane.io || true
+  kubectl get providerconfigs.kubernetes.m.crossplane.io --all-namespaces || true
+  kubectl get environmentconfigs.apiextensions.crossplane.io || true
+}
+
+show_storage_state() {
+  log "Storage resources and composed MinIO state"
+  echo "+ kubectl get storages.pkg.internal -n ${WORKSPACE_NAMESPACE}"
+  kubectl get storages.pkg.internal --namespace "${WORKSPACE_NAMESPACE}" || true
+  echo "+ kubectl get objects.kubernetes.m.crossplane.io -n ${WORKSPACE_NAMESPACE}"
+  kubectl get objects.kubernetes.m.crossplane.io --namespace "${WORKSPACE_NAMESPACE}" || true
+  echo "+ kubectl get buckets/users/policies -n ${WORKSPACE_NAMESPACE}"
+  kubectl get buckets.minio.crossplane.io,users.minio.crossplane.io,policies.minio.crossplane.io \
+    --namespace "${WORKSPACE_NAMESPACE}" || true
+  echo "+ kubectl get generated Secrets -n ${WORKSPACE_NAMESPACE}"
+  kubectl get secrets --namespace "${WORKSPACE_NAMESPACE}" || true
+}
+
 install_crossplane() {
   log "Installing Crossplane ${CROSSPLANE_VERSION}"
   apply_namespace "${CROSSPLANE_NAMESPACE}"
 
   helm repo add crossplane-stable https://charts.crossplane.io/stable --force-update
-  helm repo update
+  helm repo update crossplane-stable
   helm upgrade --install crossplane crossplane-stable/crossplane \
     --namespace "${CROSSPLANE_NAMESPACE}" \
     --version "${CROSSPLANE_VERSION}" \
@@ -290,6 +315,7 @@ EOF
 apply_examples() {
   log "Applying MinIO examples"
   ensure_workspace_provider_config
+  echo "+ kubectl apply -k examples/overlays/minio"
   kubectl apply -k examples/overlays/minio
 }
 
@@ -297,35 +323,44 @@ wait_for_storage() {
   log "Waiting for Storage examples to become ready"
   local storage
   for storage in s-joe s-jeff s-jane s-john; do
+    echo "+ kubectl wait storage.pkg.internal/${storage} -n ${WORKSPACE_NAMESPACE} --for=condition=Ready --timeout=15m"
     kubectl wait "storage.pkg.internal/${storage}" \
       --namespace "${WORKSPACE_NAMESPACE}" \
       --for=condition=Ready \
       --timeout=15m
   done
+  show_storage_state
 }
 
 mc_job() {
   local name="minio-mc-$(date +%s)-${RANDOM}"
   local script
-  script="mc alias set local http://default-hl.${MINIO_NAMESPACE}:9000 minioadmin minioadmin >/dev/null
+  script="echo '+ mc alias set local http://default-hl.${MINIO_NAMESPACE}:9000 minioadmin minioadmin'
+mc alias set local http://default-hl.${MINIO_NAMESPACE}:9000 minioadmin minioadmin >/dev/null
 $*"
 
+  echo "+ kubectl run ${name} -n ${MINIO_NAMESPACE} --image ${MINIO_MC_IMAGE} --restart=Never"
   kubectl run "${name}" \
     --namespace "${MINIO_NAMESPACE}" \
     --image "${MINIO_MC_IMAGE}" \
     --restart=Never \
     --command -- /bin/sh -ec "${script}"
 
+  echo "+ kubectl wait pod/${name} -n ${MINIO_NAMESPACE} --for=jsonpath='{.status.phase}'=Succeeded --timeout=5m"
   if ! kubectl wait "pod/${name}" \
     --namespace "${MINIO_NAMESPACE}" \
     --for=jsonpath='{.status.phase}'=Succeeded \
     --timeout=5m; then
+    echo "+ kubectl logs pod/${name} -n ${MINIO_NAMESPACE}"
     kubectl logs "pod/${name}" --namespace "${MINIO_NAMESPACE}" || true
+    echo "+ kubectl describe pod/${name} -n ${MINIO_NAMESPACE}"
     kubectl describe "pod/${name}" --namespace "${MINIO_NAMESPACE}" || true
     exit 1
   fi
 
+  echo "+ kubectl logs pod/${name} -n ${MINIO_NAMESPACE}"
   kubectl logs "pod/${name}" --namespace "${MINIO_NAMESPACE}"
+  echo "+ kubectl delete pod/${name} -n ${MINIO_NAMESPACE} --wait=false"
   kubectl delete "pod/${name}" --namespace "${MINIO_NAMESPACE}" --wait=false
 }
 
@@ -344,16 +379,19 @@ verify_minio_state() {
 
   mc_job "
 for bucket in s-joe s-jeff s-jeff-shared s-john; do
+  echo \"+ mc stat local/\${bucket}\"
   mc stat \"local/\${bucket}\" >/dev/null
   echo \"bucket \${bucket} exists\"
 done
 
 for user in s-joe-1 s-jeff-${previous_week} s-jeff-${current_week} ${jane_current} s-john-${today}; do
+  echo \"+ mc admin user info local \${user}\"
   mc admin user info local \"\${user}\" >/dev/null
   echo \"user \${user} exists\"
 done
 
 for policy in s-joe.s-joe s-jeff.s-joe s-jeff.s-jeff s-jeff.s-jeff-shared s-joe.s-jeff-shared s-jane.s-john s-john.s-john; do
+  echo \"+ mc admin policy info local \${policy}\"
   mc admin policy info local \"\${policy}\" >/dev/null
   echo \"policy \${policy} exists\"
 done
@@ -366,6 +404,7 @@ wait_for_resource() {
   local timeout_seconds="$3"
   local waited=0
 
+  echo "+ kubectl get ${resource} -n ${namespace}"
   until kubectl get "${resource}" --namespace "${namespace}" >/dev/null 2>&1; do
     if (( waited >= timeout_seconds )); then
       printf 'Timed out waiting for %s in namespace %s\n' "${resource}" "${namespace}" >&2
@@ -374,20 +413,29 @@ wait_for_resource() {
     sleep 5
     waited=$((waited + 5))
   done
+  kubectl get "${resource}" --namespace "${namespace}"
 }
 
 wait_for_job() {
   local name="$1"
 
+  echo "+ kubectl get job/${name} -n ${WORKSPACE_NAMESPACE}"
+  kubectl get "job/${name}" --namespace "${WORKSPACE_NAMESPACE}" || true
+  echo "+ kubectl wait job/${name} -n ${WORKSPACE_NAMESPACE} --for=condition=Complete --timeout=180s"
   if ! kubectl wait "job/${name}" \
     --namespace "${WORKSPACE_NAMESPACE}" \
     --for=condition=Complete \
     --timeout=180s; then
+    echo "+ kubectl logs job/${name} -n ${WORKSPACE_NAMESPACE} --all-containers=true"
     kubectl logs "job/${name}" --namespace "${WORKSPACE_NAMESPACE}" --all-containers=true || true
+    echo "+ kubectl describe job/${name} -n ${WORKSPACE_NAMESPACE}"
     kubectl describe "job/${name}" --namespace "${WORKSPACE_NAMESPACE}" || true
     exit 1
   fi
 
+  echo "+ kubectl get pods -n ${WORKSPACE_NAMESPACE} --selector=job-name=${name}"
+  kubectl get pods --namespace "${WORKSPACE_NAMESPACE}" --selector="job-name=${name}" || true
+  echo "+ kubectl logs job/${name} -n ${WORKSPACE_NAMESPACE} --all-containers=true"
   kubectl logs "job/${name}" --namespace "${WORKSPACE_NAMESPACE}" --all-containers=true
 }
 
@@ -419,12 +467,15 @@ verify_generated_secrets_and_roundtrip() {
   local secret_name
   for secret_name in s-joe s-jeff s-jane s-john; do
     wait_for_resource "secret/${secret_name}" "${WORKSPACE_NAMESPACE}" 180
+    echo "+ kubectl get secret/${secret_name} -n ${WORKSPACE_NAMESPACE}"
+    kubectl get "secret/${secret_name}" --namespace "${WORKSPACE_NAMESPACE}"
     verify_secret_has_key "${secret_name}" AWS_ACCESS_KEY_ID
     verify_secret_has_key "${secret_name}" AWS_SECRET_ACCESS_KEY
     echo "secret ${secret_name} has AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"
   done
 
   cleanup_roundtrip_jobs
+  echo "+ kubectl apply -f - # Job/s-joe-roundtrip"
   kubectl apply -f - <<EOF
 apiVersion: batch/v1
 kind: Job
@@ -471,23 +522,30 @@ spec:
               object=e2e/roundtrip.txt
               echo "writing test object to storage:s-joe/\${object}"
               printf 'provider-storage e2e roundtrip\n' >/tmp/upload.txt
+              echo "+ rclone copyto /tmp/upload.txt storage:s-joe/\${object} --s3-no-check-bucket"
               rclone copyto /tmp/upload.txt "storage:s-joe/\${object}" --s3-no-check-bucket
 
               echo "listing e2e prefix after upload"
+              echo "+ rclone lsf storage:s-joe/e2e/ --s3-no-check-bucket | sort"
               rclone lsf storage:s-joe/e2e/ --s3-no-check-bucket | sort
 
               echo "downloading test object from storage:s-joe/\${object}"
+              echo "+ rclone copyto storage:s-joe/\${object} /tmp/download.txt --s3-no-check-bucket"
               rclone copyto "storage:s-joe/\${object}" /tmp/download.txt --s3-no-check-bucket
+              echo "+ cmp /tmp/upload.txt /tmp/download.txt"
               cmp /tmp/upload.txt /tmp/download.txt
 
               echo "downloaded object content:"
+              echo "+ cat /tmp/download.txt"
               cat /tmp/download.txt
 
               echo "removing roundtrip object"
+              echo "+ rclone deletefile storage:s-joe/\${object} --s3-no-check-bucket"
               rclone deletefile "storage:s-joe/\${object}" --s3-no-check-bucket
 EOF
 
   wait_for_job s-joe-roundtrip
+  show_storage_state
   cleanup_roundtrip_jobs
 }
 
@@ -505,8 +563,10 @@ reset_lifecycle_storage() {
   cleanup_lifecycle_jobs
   log "Emptying lifecycle test bucket before reset"
   mc_job "
+echo '+ mc rm --recursive --force local/${LIFECYCLE_TEST_NAME}'
 mc rm --recursive --force local/${LIFECYCLE_TEST_NAME} || true
 "
+  echo "+ kubectl delete storage.pkg.internal/${LIFECYCLE_TEST_NAME} -n ${WORKSPACE_NAMESPACE} --ignore-not-found --wait=true --timeout=300s"
   kubectl delete "storage.pkg.internal/${LIFECYCLE_TEST_NAME}" \
     --namespace "${WORKSPACE_NAMESPACE}" \
     --ignore-not-found \
@@ -521,6 +581,7 @@ verify_lifecycle_cleanup() {
   ensure_workspace_provider_config
   reset_lifecycle_storage
 
+  echo "+ kubectl apply -f - # Storage/${LIFECYCLE_TEST_NAME}"
   kubectl apply -f - <<EOF
 apiVersion: pkg.internal/v1beta1
 kind: Storage
@@ -543,13 +604,21 @@ spec:
         provider: minio
 EOF
 
+  echo "+ kubectl wait storage.pkg.internal/${LIFECYCLE_TEST_NAME} -n ${WORKSPACE_NAMESPACE} --for=condition=Ready --timeout=300s"
   kubectl wait "storage.pkg.internal/${LIFECYCLE_TEST_NAME}" \
     --namespace "${WORKSPACE_NAMESPACE}" \
     --for=condition=Ready \
     --timeout=300s
+  show_storage_state
 
   wait_for_resource "configmap/${LIFECYCLE_TEST_NAME}-lifecycle" "${WORKSPACE_NAMESPACE}" 120
   wait_for_resource "cronjob/${LIFECYCLE_TEST_NAME}-lifecycle" "${WORKSPACE_NAMESPACE}" 120
+
+  log "Generated lifecycle resources"
+  echo "+ kubectl get configmap/${LIFECYCLE_TEST_NAME}-lifecycle -n ${WORKSPACE_NAMESPACE} -o yaml"
+  kubectl get "configmap/${LIFECYCLE_TEST_NAME}-lifecycle" --namespace "${WORKSPACE_NAMESPACE}" -o yaml
+  echo "+ kubectl get cronjob/${LIFECYCLE_TEST_NAME}-lifecycle -n ${WORKSPACE_NAMESPACE} -o yaml"
+  kubectl get "cronjob/${LIFECYCLE_TEST_NAME}-lifecycle" --namespace "${WORKSPACE_NAMESPACE}" -o yaml
 
   local generated_script expected_script
   generated_script="$(kubectl get "configmap/${LIFECYCLE_TEST_NAME}-lifecycle" \
@@ -563,6 +632,7 @@ exec rclone delete storage:${LIFECYCLE_TEST_NAME}/tmp/ --min-age 1m --fast-list 
     exit 1
   fi
 
+  echo "+ kubectl apply -f - # Job/${LIFECYCLE_TEST_NAME}-seed"
   kubectl apply -f - <<EOF
 apiVersion: batch/v1
 kind: Job
@@ -611,13 +681,18 @@ spec:
               root-keep.txt
               tmp/
               tmp/delete-me.txt'
+              echo "+ rclone delete storage:${LIFECYCLE_TEST_NAME} --s3-no-check-bucket"
               rclone delete storage:${LIFECYCLE_TEST_NAME} --s3-no-check-bucket || true
               printf 'delete after one minute\n' >/tmp/delete-me.txt
               printf 'keep at bucket root\n' >/tmp/root-keep.txt
               printf 'keep below data\n' >/tmp/data-keep.txt
+              echo "+ rclone copyto /tmp/delete-me.txt storage:${LIFECYCLE_TEST_NAME}/tmp/delete-me.txt --s3-no-check-bucket"
               rclone copyto /tmp/delete-me.txt storage:${LIFECYCLE_TEST_NAME}/tmp/delete-me.txt --s3-no-check-bucket
+              echo "+ rclone copyto /tmp/root-keep.txt storage:${LIFECYCLE_TEST_NAME}/root-keep.txt --s3-no-check-bucket"
               rclone copyto /tmp/root-keep.txt storage:${LIFECYCLE_TEST_NAME}/root-keep.txt --s3-no-check-bucket
+              echo "+ rclone copyto /tmp/data-keep.txt storage:${LIFECYCLE_TEST_NAME}/data/keep.txt --s3-no-check-bucket"
               rclone copyto /tmp/data-keep.txt storage:${LIFECYCLE_TEST_NAME}/data/keep.txt --s3-no-check-bucket
+              echo "+ rclone lsf -R storage:${LIFECYCLE_TEST_NAME} --s3-no-check-bucket | sort"
               listing="\$(rclone lsf -R storage:${LIFECYCLE_TEST_NAME} --s3-no-check-bucket | sort)"
               printf '%s\n' "\${listing}"
               if [ "\${listing}" != "\${expected}" ]; then
@@ -631,15 +706,18 @@ EOF
   log "Waiting ${LIFECYCLE_WAIT_SECONDS}s for lifecycle minAge"
   sleep "${LIFECYCLE_WAIT_SECONDS}"
 
+  echo "+ kubectl delete job/${LIFECYCLE_TEST_NAME}-cleanup-1 -n ${WORKSPACE_NAMESPACE} --ignore-not-found --wait=false"
   kubectl delete "job/${LIFECYCLE_TEST_NAME}-cleanup-1" \
     --namespace "${WORKSPACE_NAMESPACE}" \
     --ignore-not-found \
     --wait=false
+  echo "+ kubectl create job ${LIFECYCLE_TEST_NAME}-cleanup-1 -n ${WORKSPACE_NAMESPACE} --from=cronjob/${LIFECYCLE_TEST_NAME}-lifecycle"
   kubectl create job "${LIFECYCLE_TEST_NAME}-cleanup-1" \
     --namespace "${WORKSPACE_NAMESPACE}" \
     --from="cronjob/${LIFECYCLE_TEST_NAME}-lifecycle"
   wait_for_job "${LIFECYCLE_TEST_NAME}-cleanup-1"
 
+  echo "+ kubectl apply -f - # Job/${LIFECYCLE_TEST_NAME}-verify"
   kubectl apply -f - <<EOF
 apiVersion: batch/v1
 kind: Job
@@ -686,7 +764,9 @@ spec:
               expected='data/
               data/keep.txt
               root-keep.txt'
+              echo "+ rclone lsf -R storage:${LIFECYCLE_TEST_NAME} --s3-no-check-bucket | sort"
               listing="\$(rclone lsf -R storage:${LIFECYCLE_TEST_NAME} --s3-no-check-bucket | sort)"
+              echo "+ rclone lsf -R storage:${LIFECYCLE_TEST_NAME}/tmp/ --s3-no-check-bucket | sort"
               tmp_listing="\$(rclone lsf -R storage:${LIFECYCLE_TEST_NAME}/tmp/ --s3-no-check-bucket | sort)"
               echo "all objects:"
               printf '%s\n' "\${listing}"
@@ -703,16 +783,14 @@ spec:
 EOF
 
   wait_for_job "${LIFECYCLE_TEST_NAME}-verify"
+  show_storage_state
   cleanup_lifecycle_jobs
 }
 
 debug_cluster_state() {
   log "Cluster state"
-  kubectl get pods --all-namespaces || true
-  kubectl get storage.pkg.internal --namespace "${WORKSPACE_NAMESPACE}" || true
-  kubectl get buckets.minio.crossplane.io --namespace "${WORKSPACE_NAMESPACE}" || true
-  kubectl get users.minio.crossplane.io --namespace "${WORKSPACE_NAMESPACE}" || true
-  kubectl get policies.minio.crossplane.io --namespace "${WORKSPACE_NAMESPACE}" || true
+  show_core_state
+  show_storage_state
 }
 
 setup_stack() {
@@ -722,11 +800,13 @@ setup_stack() {
   install_minio
   install_minio_dependencies
   install_storage_api
+  show_core_state
 }
 
 run_example_tests() {
   log "Running example Storage e2e phase"
   apply_examples
+  show_storage_state
   wait_for_storage
   verify_minio_state
   verify_generated_secrets_and_roundtrip


### PR DESCRIPTION
- `minio/tests/e2e.bash` runs a full local MinIO end-to-end test for the Crossplane `Storage` composition.
- It creates or reuses a kind cluster, installs Crossplane, deploys MinIO, and applies the required providers, functions, RBAC, ProviderConfigs, and EnvironmentConfig.
- By default it installs the checked-out `xrd.yaml` and `minio/composition.yaml`, so it validates the exact PR contents without needing a package push.
- It applies the MinIO example `Storage` resources and waits for them to become ready.
- It verifies the real MinIO state by checking buckets, users, and policies with `mc`.
- It checks generated credentials by using the `s-joe` secret to upload, list, download, compare, and delete an object with `rclone`.
- It tests lifecycle cleanup by creating a bucket rule, triggering the generated CronJob, and verifying only matching `tmp/*` objects are removed.
- The GitHub PR workflow runs the same script in three phases: setup, example/credential tests, and lifecycle cleanup, giving CI the same coverage as local testing.
